### PR TITLE
remove unused ENR db

### DIFF
--- a/algorithme/potentiel_solaire/extract_sample_data.py
+++ b/algorithme/potentiel_solaire/extract_sample_data.py
@@ -91,7 +91,6 @@ def main():
         ("https://data.smartidf.services/api/explore/v2.1/catalog/datasets/potentiel-gisement-solaire-brut-au-bati0/exports/geojson", "potentiel-gisement-solaire-brut-au-bati.geojson"),
         ("https://data.geopf.fr/telechargement/download/BDTOPO/BDTOPO_3-4_TOUSTHEMES_GPKG_LAMB93_D093_2024-12-15/BDTOPO_3-4_TOUSTHEMES_GPKG_LAMB93_D093_2024-12-15.7z", "BDTOPO_3-4_TOUSTHEMES_GPKG_LAMB93_D093_2024-12-15.7z"),
         ("https://data.geopf.fr/telechargement/download/PARCELLAIRE-EXPRESS/PARCELLAIRE-EXPRESS_1-1__SHP_LAMB93_D093_2024-10-01/PARCELLAIRE-EXPRESS_1-1__SHP_LAMB93_D093_2024-10-01.7z", "PARCELLAIRE-EXPRESS_1-1__SHP_LAMB93_D093_2024-10-01.7z"),
-        ("https://data.geopf.fr/telechargement/download/ENR/ENR_1-0_POT-SOL-SOL_GPKG_LAMB93_FXX_2024-04-01/ENR_1-0_POT-SOL-SOL_GPKG_LAMB93_FXX_2024-04-01.7z","ENR_1-0_POT-SOL-SOL_GPKG_LAMB93_FXX_2024-04-01.7z"),
         ("https://data.geopf.fr/telechargement/download/MNS-CORREL/MNS-Correl_1-0__TIFF_LAMB93_D093_2024-01-01/MNS-Correl_1-0__TIFF_LAMB93_D093_2024-01-01.7z","MNS-Correl_1-0__TIFF_LAMB93_D093_2024-01-01.7z")
     ]
 


### PR DESCRIPTION
Cette PR a pour objectif de retirer la db ENR du script d'`extract_sample_data` puisqu'elle n'est pas utilisée. Clôture de l'issue #45.

### Comment tester ?
Lancer le script `extract_sample_data` et vérifier que la db n'est plus téléchargée. 

### Pour faciliter la validation de ma PR
- [x] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local (bonus : il fonctionne avec docker)
- [x] J'ai demandé une peer-review à un autre bénévole du projet
