### PR TITLE
fix pour recuperer les donnes PCI aussi pour les DROM

### DIFF
--- a/algorithme/data/.gitignore
+++ b/algorithme/data/.gitignore
@@ -1,6 +1,6 @@
 *.geojson
 *.7z
-*SHP_LAMB93_*
+*SHP_*
 *BDTOPO*
 *TIFF_LAMB*
 cache/

--- a/algorithme/potentiel_solaire/sources/bd_pci.py
+++ b/algorithme/potentiel_solaire/sources/bd_pci.py
@@ -26,7 +26,7 @@ def get_urls_for_bd_pci_shp(
 
     href_elements = [element.get("href") for element in soup.find_all("a") if element.get("href")]
 
-    shp_regex = rf"https?://.*PARCELLAIRE-EXPRESS.*SHP_LAMB93_D[A-Za-z0-9]{{3}}_{date}.*\.7z"
+    shp_regex = rf"https?://.*PARCELLAIRE.*SHP_.*_D[A-Za-z0-9]{{3}}_{date}.*\.7z"
 
     return [href_element for href_element in href_elements if re.search(shp_regex, href_element)]
 


### PR DESCRIPTION
### Description

### Comment tester ?
Supprimer les données PCI dans /data.

run-pipeline-algorithme -d 093
run-pipeline-algorithme -d 971

### Pour faciliter la validation de ma PR
- [x] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local (bonus : il fonctionne avec docker)
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [x] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
