### PR TITLE
feat: sql de creation de la base duckdb de test (#54)

### DIFF
--- a/application/app/api/get-communes-by-bbox/route.ts
+++ b/application/app/api/get-communes-by-bbox/route.ts
@@ -1,0 +1,29 @@
+import { fetchCommunesFromBoundingBox } from "@/app/lib/data";
+import { NextRequest } from "next/server";
+
+// an api route fetching data
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const swLat = searchParams.get("swLat");
+  const swLng = searchParams.get("swLng");
+  const neLat = searchParams.get("neLat");
+  const neLng = searchParams.get("neLng");
+  if (!swLat || !swLng || !neLat || !neLng) {
+    return Response.json(
+      { message: "Missing query parameter" },
+      {
+        status: 400,
+      }
+    );
+  }
+  try {
+    const data = await fetchCommunesFromBoundingBox({
+      southWest: { lat: Number(swLat), lng: Number(swLng) },
+      northEast: { lat: Number(neLat), lng: Number(neLng) },
+    });
+    return Response.json(data, { status: 200 });
+  } catch (error) {
+    console.error("Error while retrieving data:", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/application/app/api/get-communes/route.ts
+++ b/application/app/api/get-communes/route.ts
@@ -1,0 +1,22 @@
+import { fetchCommunes } from "@/app/lib/data";
+import { NextRequest } from "next/server";
+
+/**
+ * Get communes.
+ * Get every communes if no codeDepartement is provided.
+ * @param request
+ * @returns
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const codeDepartement = searchParams.get("codeDepartement");
+  try {
+    const data = await fetchCommunes(codeDepartement);
+    return Response.json(data, {
+      status: 200,
+    });
+  } catch (error) {
+    console.error("Error while retrieving data:", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/application/app/api/get-etablissements-by-bbox/route.ts
+++ b/application/app/api/get-etablissements-by-bbox/route.ts
@@ -1,0 +1,35 @@
+import { fetchEtablissementsFromBoundingBox } from "@/app/lib/data";
+import { NextRequest } from "next/server";
+
+/**
+ * Get etablissements from bounding box.
+ * @param request
+ * @returns
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const swLat = searchParams.get("swLat");
+  const swLng = searchParams.get("swLng");
+  const neLat = searchParams.get("neLat");
+  const neLng = searchParams.get("neLng");
+  if (!swLat || !swLng || !neLat || !neLng) {
+    return Response.json(
+      { message: "Missing query parameter" },
+      {
+        status: 400,
+      }
+    );
+  }
+  try {
+    const data = await fetchEtablissementsFromBoundingBox({
+      southWest: { lat: Number(swLat), lng: Number(swLng) },
+      northEast: { lat: Number(neLat), lng: Number(neLng) },
+    });
+    return Response.json(data, {
+      status: 200,
+    });
+  } catch (error) {
+    console.error("Error while retrieving data:", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/application/app/api/get-etablissements/route.ts
+++ b/application/app/api/get-etablissements/route.ts
@@ -1,0 +1,22 @@
+import { fetchEtablissements } from "@/app/lib/data";
+import { NextRequest } from "next/server";
+
+/**
+ * Get etablissements.
+ * Get every etablissements if no code_commune is provided.
+ * @param request
+ * @returns
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const codeCommune = searchParams.get("codeCommune");
+  try {
+    const data = await fetchEtablissements(codeCommune);
+    return Response.json(data, {
+      status: 200,
+    });
+  } catch (error) {
+    console.error("Error while retrieving data:", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/application/app/lib/data.ts
+++ b/application/app/lib/data.ts
@@ -1,0 +1,194 @@
+import { DuckDBPreparedStatement } from "@duckdb/node-api";
+import { Communes } from "../models/communes";
+import { Etablissement } from "../models/etablissements";
+import db from "./duckdb";
+
+export async function fetchEtablissements(
+  codeCommune: string | null
+): Promise<Etablissement[]> {
+  try {
+    const connection = await db.connect();
+    await connection.run("LOAD SPATIAL;");
+
+    let prepared: DuckDBPreparedStatement;
+    if (codeCommune) {
+      prepared = await connection.prepare(
+        `
+        SELECT etab.* EXCLUDE (geom), ST_X(etab.geom) as longitude, ST_Y(etab.geom) as latitude
+        FROM main.etablissements etab
+        WHERE etab.code_commune = $1;
+        `
+      );
+      prepared.bindVarchar(1, codeCommune);
+    } else {
+      prepared = await connection.prepare(
+        `
+        SELECT etab.* EXCLUDE (geom), ST_X(etab.geom) as longitude, ST_Y(etab.geom) as latitude
+        FROM main.etablissements etab;
+        `
+      );
+    }
+
+    const reader = await prepared.runAndReadAll();
+    return reader.getRowObjectsJson() as unknown as Etablissement[];
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch example rows.");
+  }
+}
+
+export async function fetchEtablissementsFromBoundingBox({
+  southWest,
+  northEast,
+}: {
+  southWest: { lat: number; lng: number };
+  northEast: { lat: number; lng: number };
+}): Promise<Etablissement[]> {
+  try {
+    const connection = await db.connect();
+    await connection.run("LOAD SPATIAL;");
+
+    const prepared = await connection.prepare(
+      `
+        SELECT etab.* EXCLUDE (geom), ST_X(etab.geom) as longitude, ST_Y(etab.geom) as latitude
+        FROM main.communes com
+        INNER JOIN main.etablissements etab ON etab.code_commune = com.code_commune
+        WHERE ST_Intersects(ST_MakeEnvelope($1, $2, $3, $4), com.geom);
+      `
+    );
+    prepared.bindDouble(1, southWest.lng);
+    prepared.bindDouble(2, southWest.lat);
+    prepared.bindDouble(3, northEast.lng);
+    prepared.bindDouble(4, northEast.lat);
+    const reader = await prepared.runAndReadAll();
+    return reader.getRowObjectsJson() as unknown as Etablissement[];
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch example rows.");
+  }
+}
+
+export async function fetchCommunesFromBoundingBox({
+  southWest,
+  northEast,
+}: {
+  southWest: { lat: number; lng: number };
+  northEast: { lat: number; lng: number };
+}): Promise<Communes> {
+  try {
+    const connection = await db.connect();
+    await connection.run("LOAD SPATIAL;");
+
+    const prepared = await connection.prepare(
+      `
+      SELECT
+      json_object(
+      'type','FeatureCollection',
+      'features',
+      COALESCE(json_group_array(
+        json_object(
+          'type','Feature',
+          'properties',
+          json_object(
+            'code_commune',
+            c.code_commune,
+            'nom_commune',
+            c.nom_commune,
+            'code_departement',
+            c.code_departement,
+            'libelle_departement',
+            c.libelle_departement,
+            'code_region',
+            c.code_region,
+            'libelle_region',
+            c.libelle_region,
+            'surface_utile',
+            c.surface_utile,
+            'rayonnement_solaire',
+            c.rayonnement_solaire,
+            'potentiel_solaire',
+            c.potentiel_solaire,
+            'protection',
+            c.protection,
+            'count_etablissements',
+            c.count_etablissements
+          ),
+          'geometry', ST_AsGeoJSON(c.geom)::JSON
+          )
+        ), [])
+      ) as geojson FROM main.departements dept
+      INNER JOIN main.communes c ON c.code_departement = dept.code_departement
+      WHERE ST_Intersects(ST_MakeEnvelope($1, $2, $3, $4), dept.geom);
+      `
+    );
+    prepared.bindDouble(1, southWest.lng);
+    prepared.bindDouble(2, southWest.lat);
+    prepared.bindDouble(3, northEast.lng);
+    prepared.bindDouble(4, northEast.lat);
+    const reader = await prepared.runAndReadAll();
+    return JSON.parse(reader.getRowsJson()[0][0] as string);
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch example rows.");
+  }
+}
+
+export async function fetchCommunes(
+  codeDepartement: string | null
+): Promise<Communes> {
+  try {
+    const connection = await db.connect();
+    await connection.run("LOAD SPATIAL;");
+
+    const prepared = await connection.prepare(
+      `
+      SELECT
+      json_object(
+      'type','FeatureCollection',
+      'features',
+      COALESCE(json_group_array(
+        json_object(
+          'type','Feature',
+          'properties',
+          json_object(
+            'code_commune',
+            c.code_commune,
+            'nom_commune',
+            c.nom_commune,
+            'code_departement',
+            c.code_departement,
+            'libelle_departement',
+            c.libelle_departement,
+            'code_region',
+            c.code_region,
+            'libelle_region',
+            c.libelle_region,
+            'surface_utile',
+            c.surface_utile,
+            'rayonnement_solaire',
+            c.rayonnement_solaire,
+            'potentiel_solaire',
+            c.potentiel_solaire,
+            'protection',
+            c.protection,
+            'count_etablissements',
+            c.count_etablissements
+          ),
+          'geometry', ST_AsGeoJSON(c.geom)::JSON
+          )
+        ), [])
+      ) as geojson FROM main.communes c
+      ` + (codeDepartement ? "WHERE c.code_departement = $1" : "")
+    );
+    if (codeDepartement) {
+      prepared.bindVarchar(1, codeDepartement);
+    }
+
+    const reader = await prepared.runAndReadAll();
+    return JSON.parse(reader.getRowsJson()[0][0] as string);
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch example rows.");
+  }
+}
+

--- a/application/app/lib/duckdb.ts
+++ b/application/app/lib/duckdb.ts
@@ -1,0 +1,35 @@
+import { DuckDBInstance } from "@duckdb/node-api";
+
+import fs from "fs";
+import path from "path";
+
+// Access the database file
+const dbFilePath = path.join(process.cwd(), "database", "data-test.duckdb");
+// Check if the file exists
+if (!fs.existsSync(dbFilePath)) {
+  throw new Error("Database file not found");
+}
+
+const duckDbSingleton = async () => {
+  console.log("Create DB instance...");
+  // next build needs access to the file and can't if not using read_only because the file gets locked - @see https://duckdb.org/docs/connect/concurrency
+  // it may be possible without it if we use the database differently or configure next (maybe ?), but as we are only reading in the db it should be better like this
+  return DuckDBInstance.create(dbFilePath, {
+    access_mode: "READ_ONLY",
+  });
+};
+
+// Ensure the global object is extended to store the Prisma client
+declare const globalThis: {
+  dbGlobal: Awaited<ReturnType<typeof duckDbSingleton>>;
+} & typeof global;
+
+// Use the existing db instance if it exists, or create a new one
+const db = globalThis.dbGlobal ?? (await duckDbSingleton());
+
+if (process.env.NODE_ENV !== "production") {
+  // Store the db instance in globalThis to reuse in development
+  globalThis.dbGlobal = db;
+}
+
+export default db;

--- a/application/app/models/communes.ts
+++ b/application/app/models/communes.ts
@@ -1,0 +1,19 @@
+export interface CommuneProperties {
+  code_commune: string;
+  nom_commune: string;
+  code_departement: string;
+  libelle_departement: string;
+  code_region: string;
+  libelle_region: string;
+  surface_utile: number;
+  rayonnement_solaire: number;
+  potentiel_solaire: number;
+  protection: boolean;
+  count_etablissements: number;
+}
+export type Commune = Communes["features"][number];
+
+export type Communes = GeoJSON.FeatureCollection<
+  GeoJSON.Geometry,
+  CommuneProperties
+>;

--- a/application/app/models/departements.ts
+++ b/application/app/models/departements.ts
@@ -1,0 +1,17 @@
+export interface DepartementProperties {
+  code_departement: string;
+  libelle_departement: string;
+  code_region: string;
+  libelle_region: string;
+  surface_utile: number;
+  rayonnement_solaire: number;
+  potentiel_solaire: number;
+  protection: boolean;
+  count_etablissements: number;
+}
+export type Departement = Departements["features"][number];
+
+export type Departements = GeoJSON.FeatureCollection<
+  GeoJSON.Geometry,
+  DepartementProperties
+>;

--- a/application/app/models/etablissements.ts
+++ b/application/app/models/etablissements.ts
@@ -14,9 +14,15 @@ export interface EtablissementProperties {
   potentiel_solaire: number;
   protection: boolean;
 }
-export type Etablissement = Etablissements["features"][number];
 
-export type Etablissements = GeoJSON.FeatureCollection<
+export type Etablissement = EtablissementProperties & {
+  longitude: number;
+  latitude: number;
+};
+
+export type EtablissementGeojson = EtablissementsGeojson["features"][number];
+
+export type EtablissementsGeojson = GeoJSON.FeatureCollection<
   GeoJSON.Geometry,
   EtablissementProperties
 >;

--- a/application/app/models/etablissements.ts
+++ b/application/app/models/etablissements.ts
@@ -1,0 +1,22 @@
+export interface EtablissementProperties {
+  identifiant_de_l_etablissement: string;
+  nom_etablissement: string;
+  type_etablissement: string;
+  libelle_nature: string;
+  code_commune: string;
+  nom_commune: string;
+  code_departement: string;
+  libelle_departement: string;
+  code_region: string;
+  libelle_region: string;
+  surface_utile: number;
+  rayonnement_solaire: number;
+  potentiel_solaire: number;
+  protection: boolean;
+}
+export type Etablissement = Etablissements["features"][number];
+
+export type Etablissements = GeoJSON.FeatureCollection<
+  GeoJSON.Geometry,
+  EtablissementProperties
+>;

--- a/application/app/models/regions.ts
+++ b/application/app/models/regions.ts
@@ -1,0 +1,15 @@
+export interface RegionProperties {
+  code_region: string;
+  libelle_region: string;
+  surface_utile: number;
+  rayonnement_solaire: number;
+  potentiel_solaire: number;
+  protection: boolean;
+  count_etablissements: number;
+}
+export type Region = Regions["features"][number];
+
+export type Regions = GeoJSON.FeatureCollection<
+  GeoJSON.Geometry,
+  RegionProperties
+>;

--- a/application/database/prepare-JDD-test.sql
+++ b/application/database/prepare-JDD-test.sql
@@ -1,0 +1,126 @@
+--INSTALL spatial;
+LOAD spatial;
+--INSTALL httpfs;
+LOAD httpfs;
+
+-- Chemin absolu du dossier contenant les fichiers source éventuels (string qui doit finir par le caractère /)
+SET VARIABLE path_to_folder = null; -- exemple : '/path/to/folder/'
+
+-- 1. création des tables depuis les fichiers geojson (la ligne commentée se base sur un fichier local qui sera plus rapide que via https)
+-- Dans certains fichiers le code etablissement n'est pas au format 0xx, on utilise donc LPAD à certains endroits pour homogénéiser le format
+-- On initialise les propriétés du potentiel_solaire de façon aléatoire :
+-- 0 < surface_utile <1000
+-- 0 < rayonnement_solaire < 100
+-- 0 < potentiel_solaire < 150
+-- protection oui/non
+-- On initialise le count_etablissements à 0, il est mis à jour dans une requête suivante (pour éviter de créer la colonne à la main)
+
+SET VARIABLE surface_utile_max = 1001;
+SET VARIABLE rayonnement_solaire_max = 101;
+SET VARIABLE potentiel_solaire_max = 151;
+
+CREATE OR REPLACE TABLE regions AS
+    SELECT reg AS code_region,
+    libgeo AS libelle_region,
+FLOOR(RANDOM() * getvariable('surface_utile_max')) AS surface_utile, 
+FLOOR(RANDOM() * getvariable('rayonnement_solaire_max')) AS rayonnement_solaire,
+FLOOR(RANDOM() * getvariable('potentiel_solaire_max')) AS potentiel_solaire,
+(RANDOM() < 0.5) AS protection,
+0 AS count_etablissements,
+geom
+FROM ST_Read('https://www.data.gouv.fr/fr/datasets/r/d993e112-848f-4446-b93b-0a9d5997c4a4') reg;  --16s
+-- FROM ST_Read(getvariable('path_to_folder') || 'a-reg2021.json') reg;
+
+CREATE OR REPLACE TABLE departements AS
+    SELECT LPAD(dep, 3, '0') AS code_departement,
+    libgeo AS libelle_departement,
+    reg AS code_region,
+    (SELECT libelle_region FROM main.regions r WHERE r.code_region = dept.reg) AS libelle_region,
+FLOOR(RANDOM() * getvariable('surface_utile_max')) AS surface_utile, 
+FLOOR(RANDOM() * getvariable('rayonnement_solaire_max')) AS rayonnement_solaire,
+FLOOR(RANDOM() * getvariable('potentiel_solaire_max')) AS potentiel_solaire,
+(RANDOM() < 0.5) AS protection,
+0 AS count_etablissements,
+    geom
+FROM ST_Read('https://www.data.gouv.fr/fr/datasets/r/92f37c92-3aae-452c-8af1-c77e6dd590e5') dept;   --40s
+-- FROM ST_Read(getvariable('path_to_folder') || 'a-dep2021.json') dept;
+
+CREATE OR REPLACE TABLE communes AS
+    SELECT
+    codgeo AS code_commune,
+    libgeo AS nom_commune,
+	LPAD(dep, 3, '0') AS code_departement,
+	(SELECT libelle_departement FROM main.departements dept WHERE dept.code_departement = LPAD(com.dep, 3, '0')) AS libelle_departement,
+	reg AS code_region,
+	(SELECT libelle_region FROM main.regions r WHERE r.code_region = com.reg) AS libelle_region,
+	FLOOR(RANDOM() * getvariable('surface_utile_max')) AS surface_utile,
+	FLOOR(RANDOM() * getvariable('rayonnement_solaire_max')) AS rayonnement_solaire,
+	FLOOR(RANDOM() * getvariable('potentiel_solaire_max')) AS potentiel_solaire,
+	(RANDOM() < 0.5) AS protection,
+0 AS count_etablissements,
+	geom
+FROM ST_Read('https://www.data.gouv.fr/fr/datasets/r/fb3580f6-e875-408d-809a-ad22fc418581') com; -- ~15 min
+-- FROM ST_Read(getvariable('path_to_folder') || 'a-com2022.json') com;
+
+
+CREATE OR REPLACE TABLE etablissements AS
+    SELECT
+	identifiant_de_l_etablissement,
+	nom_etablissement,
+	type_etablissement,
+	libelle_nature,
+	code_commune,
+	nom_commune,
+	code_departement,
+	libelle_departement,
+	code_region,
+	libelle_region,
+	FLOOR(RANDOM() * getvariable('surface_utile_max')) AS surface_utile,
+	FLOOR(RANDOM() * getvariable('rayonnement_solaire_max')) AS rayonnement_solaire,
+	FLOOR(RANDOM() * getvariable('potentiel_solaire_max')) AS potentiel_solaire,
+	(RANDOM() < 0.5) AS protection,
+	geom
+FROM ST_Read('https://data.education.gouv.fr/api/explore/v2.1/catalog/datasets/fr-en-annuaire-education/exports/geojson?lang=fr') etab; --42s
+-- FROM ST_Read(getvariable('path_to_folder') || 'fr-en-annuaire-education.geojson') etab;
+
+-- 2. maj count_etablissements depuis les tables créées
+-- certains etablissements ont le meme identifiant, peut etre que le calcul n'est pas correct
+--WITH duplicateEtablissements as(
+--SELECT identifiant_de_l_etablissement FROM main.etablissements GROUP BY identifiant_de_l_etablissement HAVING count() > 1)
+--SELECT e.* FROM duplicateEtablissements INNER JOIN main.etablissements e  ON e.identifiant_de_l_etablissement = duplicateEtablissements.identifiant_de_l_etablissement;
+
+UPDATE main.regions r SET count_etablissements = (SELECT count(*) FROM main.etablissements e WHERE r.code_region = e.code_region);
+UPDATE main.departements d SET count_etablissements = (SELECT count(*) FROM main.etablissements e WHERE d.code_departement  = e.code_departement);
+UPDATE main.communes c SET count_etablissements = (SELECT count(*) FROM main.etablissements e WHERE c.code_commune = e.code_commune );
+
+
+-- 3: export geojson (optionnel)	
+-- Il faut renseigner le chemin absolu car l'utilisation de variable dans le paramètre COPY..TO n'est pas supporté
+--COPY (
+--SELECT *
+--FROM
+--	regions
+--) 
+--TO '/path/to/folder/regions.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_NAME 'Régions');
+
+--COPY (
+--SELECT *
+--FROM
+--	departements
+--) TO '/path/to/folder/departements.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_NAME 'Départements');
+
+--COPY (
+--SELECT *
+--FROM
+--	communes
+--) TO '/path/to/folder/communes.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_NAME 'Communes');
+
+--COPY (
+--SELECT *
+--FROM
+--	etablissements
+--) TO '/path/to/folder/etablissements.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_NAME 'Etablissements');
+
+
+
+

--- a/application/next.config.ts
+++ b/application/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  serverExternalPackages: ["@duckdb/node-api"],
 };
 
 export default nextConfig;

--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -8,6 +8,7 @@
       "name": "13_potentiel_solaire_webapp",
       "version": "0.1.0",
       "dependencies": {
+        "@duckdb/node-api": "^1.2.0-alpha.14",
         "next": "15.1.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -36,6 +37,93 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@duckdb/node-api": {
+      "version": "1.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.2.0-alpha.14.tgz",
+      "integrity": "sha512-emLbLac4DuKbQO4q3Aafsn//OQbe8lMiLxxzgKPz/tgRzyOWYdiowissfWwVbhJ/JNy8Us5W+oFcGRSUWm7saA==",
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.2.0-alpha.14"
+      }
+    },
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.2.0-alpha.14.tgz",
+      "integrity": "sha512-S6L2JRnuC6yqMYgPUW81fnpFEMtbnFBHil/hXafAMKlZs3093NNAKTikU2H1sMQVDUKhAluPOaJ2AAs1k1Ixbw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.2.0-alpha.14",
+        "@duckdb/node-bindings-darwin-x64": "1.2.0-alpha.14",
+        "@duckdb/node-bindings-linux-arm64": "1.2.0-alpha.14",
+        "@duckdb/node-bindings-linux-x64": "1.2.0-alpha.14",
+        "@duckdb/node-bindings-win32-x64": "1.2.0-alpha.14"
+      }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.2.0-alpha.14.tgz",
+      "integrity": "sha512-DUnWLs+r5ePntaxld+mk/lxDwIT8PBrXY8yMnzb5HTWSFdcHWF2UIeuMhLFgVcyQnm7r5pRjd36XeffMQPVFGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.2.0-alpha.14.tgz",
+      "integrity": "sha512-RqzFF/4yZseNAK6dv3kNL+YUgkTsqFrLTAmgG65YTN8YWHv5VYBtb9NKETb5gZi9GVQ4+d5cc5tuKOXXPRhB3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.2.0-alpha.14.tgz",
+      "integrity": "sha512-1EcGTDiwtas0eJeFWmzZsKqHCDBrt1TBPnL2il9s9mKYYcbBYkwtsVCgtO5BH8XmgNEM4WxVfGtR6KwJ90ymoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.2.0-alpha.14.tgz",
+      "integrity": "sha512-B9EfSZosrMhFVdgi3WKV854Vj8tnE4ywW3aXqNQ73qLZ4gBnKdiZYXdpt9Eed4qJv4cvQ4PWege3TThD/SOv8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.2.0-alpha.14.tgz",
+      "integrity": "sha512-v565LwMjVoV4Tn/D2RazmQhesKnl3cUHO/VXP1gS46sLsEdXMkNjDUNa4RiGy0LCWT+SPKsaAex8BJoPHXVTMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.3.1",

--- a/application/package.json
+++ b/application/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@duckdb/node-api": "^1.2.0-alpha.14",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "next": "15.1.6"


### PR DESCRIPTION
### Description
Issue : #54 

Cette PR a pour objectif de fournir une architecture nécessaire pour requête une base duckdb.
- un scrip sql pour initialiser une base de test
- les modèles de données associés (typescript)
- un accès à la base duckdb
- une exposition d'api routes de test

Le script `prepare-JDD-test.sql` permet de créer une base de données avec les tables pré-remplit avec des données de test.
Il utilise des urls http pointant sur les sources suivantes : 
- régions, départements, communes : https://www.data.gouv.fr/fr/datasets/contours-des-communes-de-france-simplifie-avec-regions-et-departement-doutre-mer-rapproches/#/resources
- établissements : https://data.education.gouv.fr/explore/dataset/fr-en-annuaire-education/

**Le chargement des communes est très long (~ 15 min), il est donc recommandé de charger les fichiers sur son ordinateur et de les utiliser directement (c'est indiqué dans le script SQL comment modifier)**
La dernière partie du script commentée permet de générer des fichiers `.geojson` statiques correspondants aux tables.

Pour initialiser une base duckdb : 

En utilisant le CLI : 
1. Télécharger le CLI pour son environnement - https://duckdb.org/docs/installation/?version=stable&environment=cli

Pour linux, par exemple : 
`curl https://install.duckdb.org | sh`

2. Se rendre dans le répertoire où se trouve le script SQL
`cd /path/to/folder`

3. Lancer la commande de création de la base
`duckdb < prepare-JDD-test.sql data-test.duckdb` ou `duckdb -init prepare-JDD-test.sql -no-stdin data-test.duckdb`

En utilisant un éditeur SQL, par exemple DBeaver : https://dbeaver.io/

1. Installer l'outil
2. Créer une connexion duckdb en choisissant l'option pour créer une base et lui fournir un chemin pour la base de données
3. Ouvrir le script sql sur cette nouvelle base de données et l'executer
