### PR TITLE
[FRONT] feat: use specific icon on map for etablissement protege

### DIFF
--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -54,6 +54,8 @@ import {
 	clusterCountLayer,
 	clusterLayer,
 	unclusteredPointLayer,
+	unclusteredPointProtegeIconLayer,
+	unclusteredPointProtegeLayer,
 } from './layers/etablissementsLayers';
 import {
 	REGIONS_LABELS_SOURCE_ID,
@@ -505,6 +507,12 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 						)}
 						{isEtablissementsLayerVisible && (
 							<LayerReactMapLibre {...unclusteredPointLayer} />
+						)}
+						{isEtablissementsLayerVisible && (
+							<LayerReactMapLibre {...unclusteredPointProtegeLayer} />
+						)}
+						{isEtablissementsLayerVisible && (
+							<LayerReactMapLibre {...unclusteredPointProtegeIconLayer} />
 						)}
 					</Source>
 				)}

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -376,7 +376,10 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 			return;
 		}
 
-		if (isFeatureFrom<EventEtablissementFeature>(feature, unclusteredPointLayer)) {
+		if (
+			isFeatureFrom<EventEtablissementFeature>(feature, unclusteredPointLayer) ||
+			isFeatureFrom<EventEtablissementFeature>(feature, unclusteredPointProtegeLayer)
+		) {
 			handleClickOnEtablissement(feature);
 
 			return;
@@ -404,6 +407,7 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 					communesTransparentLayer.id,
 					clusterLayer.id,
 					unclusteredPointLayer.id,
+					unclusteredPointProtegeLayer.id,
 				]}
 				onClick={onClick}
 				onLoad={() => {
@@ -519,7 +523,6 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 			</MapFromReactMapLibre>
 			{level !== 'nation' && <BackButton onBack={goBackOneLevel} />}
 			<div className='z-30 !mb-24 flex flex-col items-start justify-center gap-4 px-4 md:mb-6 md:flex-row md:items-center md:justify-center'>
-
 				<Legend thresholds={COLOR_THRESHOLDS[level]} />
 				<MenuDrom />
 			</div>

--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -32,7 +32,11 @@ export const unclusteredPointLayer = {
 	id: 'unclustered-point',
 	type: 'circle',
 	source: ETABLISSEMENTS_SOURCE_ID,
-	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], false]],
+	filter: [
+		'all',
+		['!', ['has', 'point_count']],
+		['==', ['get', EtablissementFeaturePropertiesKeys.Protection], false],
+	],
 	paint: {
 		'circle-color': [
 			'step',
@@ -47,11 +51,15 @@ export const unclusteredPointProtegeLayer = {
 	id: 'unclustered-point-protege',
 	type: 'circle',
 	source: ETABLISSEMENTS_SOURCE_ID,
-	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], true]],
+	filter: [
+		'all',
+		['!', ['has', 'point_count']],
+		['==', ['get', EtablissementFeaturePropertiesKeys.Protection], true],
+	],
 	paint: {
 		'circle-color': [
 			'step',
-			['get', 'potentiel_solaire'],
+			['get', EtablissementFeaturePropertiesKeys.PotentielSolaire],
 			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
 		],
 		'circle-radius': 15,
@@ -64,7 +72,11 @@ export const unclusteredPointProtegeIconLayer = {
 	id: 'unclustered-point-protege-icon',
 	type: 'symbol',
 	source: ETABLISSEMENTS_SOURCE_ID,
-	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], true]],
+	filter: [
+		'all',
+		['!', ['has', 'point_count']],
+		['==', ['get', EtablissementFeaturePropertiesKeys.Protection], true],
+	],
 	layout: {
 		'text-field': 'i',
 		'text-size': 20,

--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -56,6 +56,7 @@ export const unclusteredPointProtegeLayer = {
 		],
 		'circle-radius': 15,
 		'circle-stroke-width': 2,
+		'circle-stroke-color': '#221c3e',
 	},
 } satisfies LayerProps;
 
@@ -65,7 +66,10 @@ export const unclusteredPointProtegeIconLayer = {
 	source: ETABLISSEMENTS_SOURCE_ID,
 	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], true]],
 	layout: {
-		'text-field': ' i ',
+		'text-field': 'i',
 		'text-size': 20,
+	},
+	paint: {
+		'text-color': '#221c3e',
 	},
 } satisfies LayerProps;

--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -55,6 +55,7 @@ export const unclusteredPointProtegeLayer = {
 			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
 		],
 		'circle-radius': 15,
+		'circle-stroke-width': 2,
 	},
 } satisfies LayerProps;
 
@@ -64,8 +65,7 @@ export const unclusteredPointProtegeIconLayer = {
 	source: ETABLISSEMENTS_SOURCE_ID,
 	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], true]],
 	layout: {
-		'text-field': ' ⓘ ',
+		'text-field': ' i ',
 		'text-size': 20,
-		'text-offset': [0, -0.1], // offset to center the icon as the character is slightly shifted towards bottom
 	},
 } satisfies LayerProps;

--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -32,7 +32,7 @@ export const unclusteredPointLayer = {
 	id: 'unclustered-point',
 	type: 'circle',
 	source: ETABLISSEMENTS_SOURCE_ID,
-	filter: ['!', ['has', 'point_count']],
+	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], false]],
 	paint: {
 		'circle-color': [
 			'step',
@@ -40,5 +40,32 @@ export const unclusteredPointLayer = {
 			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
 		],
 		'circle-radius': 15,
+	},
+} satisfies LayerProps;
+
+export const unclusteredPointProtegeLayer = {
+	id: 'unclustered-point-protege',
+	type: 'circle',
+	source: ETABLISSEMENTS_SOURCE_ID,
+	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], true]],
+	paint: {
+		'circle-color': [
+			'step',
+			['get', 'potentiel_solaire'],
+			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
+		],
+		'circle-radius': 15,
+	},
+} satisfies LayerProps;
+
+export const unclusteredPointProtegeIconLayer = {
+	id: 'unclustered-point-protege-icon',
+	type: 'symbol',
+	source: ETABLISSEMENTS_SOURCE_ID,
+	filter: ['all', ['!', ['has', 'point_count']], ['==', ['get', 'protection'], true]],
+	layout: {
+		'text-field': ' ⓘ ',
+		'text-size': 20,
+		'text-offset': [0, -0.1], // offset to center the icon as the character is slightly shifted towards bottom
 	},
 } satisfies LayerProps;


### PR DESCRIPTION
### Description
Github issue : #195 

Cette PR a pour objectif de d'améliorer la visisilité des etablisssements protégés.
Avec une icone spécifique sur la carte.
On s'assure aussi que la section "batiment protégé" n'est pas affiché dans la fiche établissement si `protection` = false.

### Comment tester ?
Lancer l'application et vérifier que les batiment protégés ont bien une icone spécifique sur la carte. 
Au clic sur une fiche etablissement avec protection à true, on a un bloc dédié.
Au clic sur une fiche établissement avec protection à false, aucun bloc dédié.

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)