### PR TITLE
[FRONT] Echelle de légende 

### DIFF
--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -311,7 +311,7 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 	}
 
 	return (
-		<div className='relative h-[80vh] w-full sm:h-[600px] md:h-[800px] lg:h-[1000px]'>
+		<div className='relative h-full w-full'>
 			<MapFromReactMapLibre
 				ref={mapRef}
 				initialViewState={initialViewState}
@@ -429,9 +429,9 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 				)}
 			</MapFromReactMapLibre>
 			{level !== 'regions' && <BackButton onBack={goBackOneLevel} />}
-			<div className='absolute bottom-2 left-2 flex flex-col items-start md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:flex-row md:items-center md:gap-4'>
+			<div className='absolute bottom-2 left-2 z-50 flex flex-col items-start md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:flex-row md:items-center md:gap-4'>
 				<Legend thresholds={COLOR_THRESHOLDS[level]} />
-				{isRegionsLayerVisible && (
+				{(isRegionsLayerVisible || isDepartementsLayerVisible) && (
 					<MenuDrom onClickDrom={handleClickOnDroms} onClickMetropole={handleResetMap} />
 				)}
 			</div>

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -431,7 +431,7 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 			{level !== 'regions' && <BackButton onBack={goBackOneLevel} />}
 			<div className='absolute bottom-2 left-2 z-50 flex flex-col items-start md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:flex-row md:items-center md:gap-4'>
 				<Legend thresholds={COLOR_THRESHOLDS[level]} />
-				{(isRegionsLayerVisible || isDepartementsLayerVisible) && (
+				{isRegionsLayerVisible && (
 					<MenuDrom onClickDrom={handleClickOnDroms} onClickMetropole={handleResetMap} />
 				)}
 			</div>

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -302,8 +302,8 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 		}
 	}
 
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		function handleOnLocate(feature: CommuneFeature) {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	function handleOnLocate(feature: CommuneFeature) {
 		if (!mapRef.current) return;
 
 		handleClickOnCommunes(feature);
@@ -429,7 +429,7 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 				)}
 			</MapFromReactMapLibre>
 			{level !== 'regions' && <BackButton onBack={goBackOneLevel} />}
-			<div className='absolute bottom-2 left-2 flex flex-col items-center md:flex-row md:gap-4'>
+			<div className='absolute bottom-2 left-2 flex flex-col items-start md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:flex-row md:items-center md:gap-4'>
 				<Legend thresholds={COLOR_THRESHOLDS[level]} />
 				{isRegionsLayerVisible && (
 					<MenuDrom onClickDrom={handleClickOnDroms} onClickMetropole={handleResetMap} />

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -429,7 +429,7 @@ export default function FranceMap({ onSelect }: FranceMapProps) {
 				)}
 			</MapFromReactMapLibre>
 			{level !== 'regions' && <BackButton onBack={goBackOneLevel} />}
-			<div className='absolute bottom-2 left-2 flex flex-col items-start md:flex-row md:gap-4'>
+			<div className='absolute bottom-2 left-2 flex flex-col items-center md:flex-row md:gap-4'>
 				<Legend thresholds={COLOR_THRESHOLDS[level]} />
 				{isRegionsLayerVisible && (
 					<MenuDrom onClickDrom={handleClickOnDroms} onClickMetropole={handleResetMap} />

--- a/application/app/components/Map/Legend/Legend.tsx
+++ b/application/app/components/Map/Legend/Legend.tsx
@@ -25,7 +25,7 @@ export default function Legend({ thresholds }: Legend) {
 	const lastThresholdUnit = getClosestEnergyUnit(lastThreshold);
 
 	return (
-		<div className='pointer-events-none flex flex-grow-0 flex-col items-center rounded-md bg-background p-1 text-sm text-foreground'>
+		<div className='pointer-events-none flex flex-grow-0 flex-col items-center rounded-md bg-blue p-2 text-sm text-white'>
 			{getLabel(lastThresholdUnit)}
 			<LegendColorScale thresholds={thresholds} unit={lastThresholdUnit} />
 		</div>
@@ -74,13 +74,13 @@ function LegendColorScale({ thresholds, unit }: LegendColorScale) {
 					fillOpacity={OPACITY}
 					rx={BORDER_RADIUS}
 				/>
-				{thresholdValues.slice(1).map(([thresholdValue], i) => (
+				{thresholdValues.map(([thresholdValue], i) => (
 					<text
 						key={thresholdValue}
-						x={sliceWidth * (i + 1) + BORDER_RADIUS}
+						x={sliceWidth * i + BORDER_RADIUS}
 						y={sliceHeight + 15}
 						textAnchor='middle'
-						className='fill-foreground font-normal opacity-80'
+						className='fill-white font-normal opacity-80'
 					>
 						{Math.round(convertKWhTo(Number(thresholdValue), unit))}
 					</text>

--- a/application/app/components/Map/MapWithFiches.tsx
+++ b/application/app/components/Map/MapWithFiches.tsx
@@ -13,8 +13,10 @@ export default function MapWithFiches() {
 	);
 
 	return (
-		<div>
-			<FranceMap onSelect={setSelectedEtablissement} />
+		<div className='flex flex-1 flex-col'>
+			<div className='flex-1'>
+				<FranceMap onSelect={setSelectedEtablissement} />
+			</div>
 			{selectedEtablissement && (
 				<Fiches
 					etablissement={{

--- a/application/app/components/Map/MenuDrom.tsx
+++ b/application/app/components/Map/MenuDrom.tsx
@@ -54,7 +54,8 @@ const LOCATIONS: MenuDromLocation[] = [
 ];
 
 const buttonStyle =
-	'flex h-12 w-12 items-center justify-center rounded-md bg-blue border border-white text-sm font-semibold shadow-md';
+	'flex items-center justify-center rounded-md bg-blue border border-white text-sm font-semibold shadow-md flex-shrink-0'
+	+ ' h-[clamp(2rem,10vw,3rem)] w-[clamp(2rem,10vw,3rem)]';
 const buttonActiveStyle = 'bg-gray-400';
 const buttonHoverStyle = 'hover:bg-white';
 

--- a/application/app/components/Map/MenuDrom.tsx
+++ b/application/app/components/Map/MenuDrom.tsx
@@ -54,8 +54,8 @@ const LOCATIONS: MenuDromLocation[] = [
 ];
 
 const buttonStyle =
-	'flex items-center justify-center rounded-md bg-blue border border-white text-sm font-semibold shadow-md flex-shrink-0'
-	+ ' h-[clamp(2rem,10vw,3rem)] w-[clamp(2rem,10vw,3rem)]';
+	'flex items-center justify-center rounded-md bg-blue border border-white text-sm font-semibold shadow-md flex-shrink-0' +
+	' h-[clamp(2rem,10vw,3rem)] w-[clamp(2rem,10vw,3rem)]';
 const buttonActiveStyle = 'bg-gray-400';
 const buttonHoverStyle = 'hover:bg-white';
 
@@ -68,17 +68,16 @@ function MenuDrom({ onClickDrom, onClickMetropole }: MenuDromProps) {
 	const [activeTab, setActiveTab] = useState('hexagone');
 	const [isOpen, setIsOpen] = useState(true);
 
-	function handleTabChange(location: MenuDromLocation) {
-		setActiveTab(location.code);
+  function handleTabChange(location: MenuDromLocation) {
+    setActiveTab(location.code);
 
-		if (location.code === 'hexagone') {
-			onClickMetropole();
+    if (location.code === 'hexagone') {
+      onClickMetropole();
+      return;
+    }
 
-			return;
-		}
-
-		onClickDrom(location);
-	}
+    onClickDrom(location);
+  }
 
 	const activeLocation = LOCATIONS.find((location) => location.code === activeTab);
 
@@ -87,7 +86,7 @@ function MenuDrom({ onClickDrom, onClickMetropole }: MenuDromProps) {
 	}
 
 	return (
-		<div className='mt-2 flex w-full max-w-sm flex-row justify-center gap-2 bg-transparent'>
+		<div className='mt-2 flex w-full max-w-sm flex-row justify-start gap-2 bg-transparent md:justify-center'>
 			<button onClick={() => setIsOpen(!isOpen)} className={buttonStyle}>
 				{isOpen ? (
 					<X color='white' />

--- a/application/app/layout.tsx
+++ b/application/app/layout.tsx
@@ -19,11 +19,11 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang='en' className='h-full'>
-			<body className='flex h-full flex-col'>
+			<body className='flex min-h-screen flex-col'>
 				<header className='sticky top-0 z-50'>
 					<NavBar />
 				</header>
-				<main className='h-full flex-1'>
+				<main className='flex flex-1 flex-col'>
 					<Providers>{children}</Providers>
 				</main>
 				<Toaster />

--- a/application/app/page.tsx
+++ b/application/app/page.tsx
@@ -1,22 +1,11 @@
 'use client';
 
 import MapWithFiches from './components/Map/MapWithFiches';
-import SearchBar from './components/SearchBar/SearchBar';
-import { SearchResult } from './models/search';
 
 export default function Home() {
-	function handleSearchSelect(selection: SearchResult) {
-		alert(selection.libelle + ' - ' + selection.source);
-	}
-
 	return (
-		<div className='flex h-screen flex-col'>
-			<div className='p-4'>
-				<SearchBar onSelect={handleSearchSelect} />
-			</div>
-			<div className='flex-1'>
-				<MapWithFiches />
-			</div>
+		<div className='flex flex-1 flex-col'>
+			<MapWithFiches />
 		</div>
 	);
 }

--- a/application/app/styles/globals.css
+++ b/application/app/styles/globals.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body {
+	height: 100%;
+	margin: 0;
+	padding: 0;
+}
+
 @layer base {
 	:root {
 		--background: 0 0% 100%;

--- a/application/public/map-styles/map-style.json
+++ b/application/public/map-styles/map-style.json
@@ -44,7 +44,7 @@
 			},
 			"paint": {
 				"fill-antialias": false,
-				"fill-color": "#38435C"
+				"fill-color": "#221C3E"
 			}
 		},
 		{


### PR DESCRIPTION
### Description
Github issue : _[#194](https://github.com/dataforgoodfr/13_potentiel_solaire/issues/194)_

Cette PR a pour objectif de corriger l'affichage de l’échelle sur la carte, conformément aux maquettes Figma :

Ajout explicite de la valeur minimale 0 sur l’échelle.
Application du fond sombre à l’échelle (dark mode) pour correspondre à la charte graphique.
Elle inclut également deux améliorations complémentaires :

Correction du responsive design du composant MenuDrom, en rendant les boutons adaptatifs.
Harmonisation de la couleur bleue dans le map-style avec celle définie dans la charte graphique.

### Comment tester ?

Lancer l’application (npm run dev) et vérifier l'affichage de l’échelle :
- Une valeur "0" est bien visible au début de l’échelle.
- Le fond est sombre avec un texte clair, fidèle au design Figma.

Tester l’affichage du MenuDrom :
- Sur des écrans de différentes tailles, le menu reste sur une seule ligne.
- Les boutons se redimensionnent proprement sans débordement.

Vérifier sur la carte que les couleurs correspondent à celles de la charte graphique (notamment le bleu principal).


### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet


### Bonnes pratiques de code
#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
