### PR TITLE
refactor: remove constant for model keys

### DIFF
--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -24,8 +24,8 @@ import { EaseToOptions, GeoJSONSource } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import {
+	ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE,
 	EtablissementFeature,
-	EtablissementFeaturePropertiesKeys,
 } from '../../models/etablissements';
 import Loading from '../Loading';
 import BackButton from './BackButton';
@@ -498,7 +498,7 @@ export default function FranceMap() {
 						clusterProperties={{
 							potentiel_solaire: [
 								'number',
-								['get', EtablissementFeaturePropertiesKeys.PotentielSolaire],
+								['get', ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE],
 							],
 						}}
 					>

--- a/application/app/components/Map/layers/communesLayers.ts
+++ b/application/app/components/Map/layers/communesLayers.ts
@@ -1,6 +1,6 @@
 import { LayerProps } from 'react-map-gl/maplibre';
 
-import { CommuneFeaturePropertiesKeys } from '@/app/models/communes';
+import { COMMUNE_GEOJSON_KEY_NOM } from '@/app/models/communes';
 
 import { COLOR_THRESHOLDS } from '../constants';
 import { zonesLayerPaint } from './zonesLayersPaint';
@@ -37,7 +37,7 @@ export const communesLabelsLayer = {
 	type: 'symbol',
 	source: COMMUNES_LABELS_SOURCE_ID,
 	layout: {
-		'text-field': ['get', CommuneFeaturePropertiesKeys.Nom],
+		'text-field': ['get', COMMUNE_GEOJSON_KEY_NOM],
 		'text-size': 10,
 		'text-anchor': 'center',
 	},

--- a/application/app/components/Map/layers/departementsLayers.ts
+++ b/application/app/components/Map/layers/departementsLayers.ts
@@ -1,6 +1,6 @@
 import { LayerProps } from 'react-map-gl/maplibre';
 
-import { DepartementFeaturePropertiesKeys } from '@/app/models/departements';
+import { DEPARTEMENT_GEOJSON_KEY_NOM } from '@/app/models/departements';
 
 import { COLOR_THRESHOLDS } from '../constants';
 import { zonesLayerPaint } from './zonesLayersPaint';
@@ -26,7 +26,7 @@ export const departementsLabelsLayer = {
 	type: 'symbol',
 	source: DEPARTEMENTS_LABELS_SOURCE_ID,
 	layout: {
-		'text-field': ['get', DepartementFeaturePropertiesKeys.Nom],
+		'text-field': ['get', DEPARTEMENT_GEOJSON_KEY_NOM],
 		'text-size': 12,
 		'text-anchor': 'center',
 		'text-max-width': 5,

--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -1,4 +1,7 @@
-import { EtablissementFeaturePropertiesKeys } from '@/app/models/etablissements';
+import {
+	ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE,
+	ETABLISSEMENT_GEOJSON_KEY_PROTECTION,
+} from '@/app/models/etablissements';
 import type { LayerProps } from '@vis.gl/react-maplibre';
 
 import { COLOR_THRESHOLDS } from '../constants';
@@ -35,12 +38,12 @@ export const unclusteredPointLayer = {
 	filter: [
 		'all',
 		['!', ['has', 'point_count']],
-		['==', ['get', EtablissementFeaturePropertiesKeys.Protection], false],
+		['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], false],
 	],
 	paint: {
 		'circle-color': [
 			'step',
-			['get', EtablissementFeaturePropertiesKeys.PotentielSolaire],
+			['get', ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE],
 			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
 		],
 		'circle-radius': 15,
@@ -54,12 +57,12 @@ export const unclusteredPointProtegeLayer = {
 	filter: [
 		'all',
 		['!', ['has', 'point_count']],
-		['==', ['get', EtablissementFeaturePropertiesKeys.Protection], true],
+		['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], true],
 	],
 	paint: {
 		'circle-color': [
 			'step',
-			['get', EtablissementFeaturePropertiesKeys.PotentielSolaire],
+			['get', ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE],
 			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
 		],
 		'circle-radius': 15,
@@ -75,7 +78,7 @@ export const unclusteredPointProtegeIconLayer = {
 	filter: [
 		'all',
 		['!', ['has', 'point_count']],
-		['==', ['get', EtablissementFeaturePropertiesKeys.Protection], true],
+		['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], true],
 	],
 	layout: {
 		'text-field': 'i',

--- a/application/app/components/Map/layers/regionsLayers.ts
+++ b/application/app/components/Map/layers/regionsLayers.ts
@@ -1,6 +1,6 @@
 import { LayerProps } from 'react-map-gl/maplibre';
 
-import { RegionFeaturePropertiesKeys } from '@/app/models/regions';
+import { REGIONS_GEOJSON_KEY_NOM } from '@/app/models/regions';
 
 import { COLOR_THRESHOLDS } from '../constants';
 import { zonesLayerPaint } from './zonesLayersPaint';
@@ -26,7 +26,7 @@ export const regionsLabelsLayer = {
 	type: 'symbol',
 	source: REGIONS_LABELS_SOURCE_ID,
 	layout: {
-		'text-field': ['get', RegionFeaturePropertiesKeys.Nom],
+		'text-field': ['get', REGIONS_GEOJSON_KEY_NOM],
 		'text-size': 12,
 		'text-anchor': 'center',
 		'text-max-width': 5,

--- a/application/app/components/Map/layers/zonesLayersPaint.ts
+++ b/application/app/components/Map/layers/zonesLayersPaint.ts
@@ -1,14 +1,20 @@
-import { ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY } from '@/app/models/common';
+import { CommuneFeatureProperties } from '@/app/models/communes';
+import { DepartementFeatureProperties } from '@/app/models/departements';
+import { RegionFeatureProperties } from '@/app/models/regions';
 import { FillLayerSpecification } from 'maplibre-gl';
 
 import { Thresholds } from '../constants';
 import thresholdsToStepColorsParams from './thresholdsToColorsParams';
 
+const ZONE_GEOJSON_KEY_POTENTIEL_SOLAIRE_TOTAL: keyof DepartementFeatureProperties &
+	keyof CommuneFeatureProperties &
+	keyof RegionFeatureProperties = 'potentiel_solaire_total';
+
 export function zonesLayerPaint(thresholds: Thresholds, isBackground: boolean) {
 	const fillColors = thresholdsToStepColorsParams(thresholds);
 
 	return {
-		'fill-color': ['step', ['get', ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.TOTAL], ...fillColors],
+		'fill-color': ['step', ['get', ZONE_GEOJSON_KEY_POTENTIEL_SOLAIRE_TOTAL], ...fillColors],
 		'fill-opacity': isBackground ? 0.5 : 1,
 		'fill-outline-color': 'black',
 	} satisfies FillLayerSpecification['paint'];

--- a/application/app/components/SearchBar/SearchBar.tsx
+++ b/application/app/components/SearchBar/SearchBar.tsx
@@ -2,11 +2,7 @@
 
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 
-import { CommunePropertiesKeys } from '@/app/models/communes';
-import { DepartementPropertiesKeys } from '@/app/models/departements';
-import { EtablissementPropertiesKeys } from '@/app/models/etablissements';
-import { RegionPropertiesKeys } from '@/app/models/regions';
-import { SearchPropertiesKeys, SearchResult } from '@/app/models/search';
+import { SearchResult } from '@/app/models/search';
 import useCommune from '@/app/utils/hooks/useCommune';
 import useDebouncedSearch from '@/app/utils/hooks/useDebouncedSearch';
 import useDepartement from '@/app/utils/hooks/useDepartement';
@@ -62,32 +58,20 @@ export default function SearchBar({ onSelect }: SearchBarProps) {
 
 function useChangeCodesOnSelection(selection: SearchResult | null, onChange?: () => void) {
 	const { setCodes } = useURLParams();
-	const { region } = useRegion(
-		selection?.[SearchPropertiesKeys.Source] === 'regions'
-			? selection?.[SearchPropertiesKeys.Id]
-			: null,
-	);
+	const { region } = useRegion(selection?.source === 'regions' ? selection?.id : null);
 	const { departement } = useDepartement(
-		selection?.[SearchPropertiesKeys.Source] === 'departements'
-			? selection?.[SearchPropertiesKeys.Id]
-			: null,
+		selection?.source === 'departements' ? selection?.id : null,
 	);
-	const { commune } = useCommune(
-		selection?.[SearchPropertiesKeys.Source] === 'communes'
-			? selection?.[SearchPropertiesKeys.Id]
-			: null,
-	);
+	const { commune } = useCommune(selection?.source === 'communes' ? selection?.id : null);
 	const { etablissement } = useEtablissement(
-		selection?.[SearchPropertiesKeys.Source] === 'etablissements'
-			? selection?.[SearchPropertiesKeys.Id]
-			: null,
+		selection?.source === 'etablissements' ? selection?.id : null,
 	);
 
 	useEffect(() => {
 		if (region != null) {
 			setCodes(
 				{
-					codeRegion: region[RegionPropertiesKeys.Id],
+					codeRegion: region.code_region,
 					codeDepartement: null,
 					codeCommune: null,
 					codeEtablissement: null,
@@ -99,8 +83,8 @@ function useChangeCodesOnSelection(selection: SearchResult | null, onChange?: ()
 		if (departement != null) {
 			setCodes(
 				{
-					codeRegion: departement[DepartementPropertiesKeys.CodeRegion],
-					codeDepartement: departement[DepartementPropertiesKeys.Id],
+					codeRegion: departement.code_region,
+					codeDepartement: departement.code_departement,
 					codeCommune: null,
 					codeEtablissement: null,
 				},
@@ -111,9 +95,9 @@ function useChangeCodesOnSelection(selection: SearchResult | null, onChange?: ()
 		if (commune != null) {
 			setCodes(
 				{
-					codeRegion: commune[CommunePropertiesKeys.CodeRegion],
-					codeDepartement: commune[CommunePropertiesKeys.CodeDepartement],
-					codeCommune: commune[CommunePropertiesKeys.Id],
+					codeRegion: commune.code_region,
+					codeDepartement: commune.code_departement,
+					codeCommune: commune.code_commune,
 					codeEtablissement: null,
 				},
 				true,
@@ -123,10 +107,10 @@ function useChangeCodesOnSelection(selection: SearchResult | null, onChange?: ()
 		if (etablissement != null) {
 			setCodes(
 				{
-					codeRegion: etablissement[EtablissementPropertiesKeys.CodeRegion],
-					codeDepartement: etablissement[EtablissementPropertiesKeys.CodeDepartement],
-					codeCommune: etablissement[EtablissementPropertiesKeys.CodeCommune],
-					codeEtablissement: etablissement[EtablissementPropertiesKeys.Id],
+					codeRegion: etablissement.code_region,
+					codeDepartement: etablissement.code_departement,
+					codeCommune: etablissement.code_commune,
+					codeEtablissement: etablissement.identifiant_de_l_etablissement,
 				},
 				true,
 			);

--- a/application/app/lib/data.ts
+++ b/application/app/lib/data.ts
@@ -1,23 +1,14 @@
 import { DuckDBPreparedStatement } from '@duckdb/node-api';
 
-import {
-	Commune,
-	CommuneFeature,
-	CommunePropertiesKeys,
-	CommunesGeoJSON,
-} from '../models/communes';
-import {
-	Departement,
-	DepartementPropertiesKeys,
-	DepartementsGeoJSON,
-} from '../models/departements';
+import { Commune, CommuneFeature, CommunesGeoJSON } from '../models/communes';
+import { Departement, DepartementsGeoJSON } from '../models/departements';
 import {
 	Etablissement,
 	EtablissementWithLatLng,
 	EtablissementsGeoJSON,
 } from '../models/etablissements';
-import { Region, RegionPropertiesKeys } from '../models/regions';
-import { SearchPropertiesKeys, SearchResult } from '../models/search';
+import { Region } from '../models/regions';
+import { SearchResult } from '../models/search';
 import { isCodePostal, sanitizeString } from '../utils/string-utils';
 import {
 	COMMUNES_COLUMNS,
@@ -432,17 +423,13 @@ export async function fetchCommuneById(id: string): Promise<Commune | null> {
 		// TODO: check if duckdb can do this
 		return {
 			...result,
-			[CommunePropertiesKeys.TopEtablissementsTotal]: JSON.parse(
-				result[CommunePropertiesKeys.TopEtablissementsTotal] as string,
+			top_etablissements_total: JSON.parse(result.top_etablissements_total as string),
+			top_etablissements_primaires: JSON.parse(result.top_etablissements_primaires as string),
+			nb_etablissements_par_niveau_potentiel_total: JSON.parse(
+				result.nb_etablissements_par_niveau_potentiel_total as string,
 			),
-			[CommunePropertiesKeys.TopEtablissementsPrimaires]: JSON.parse(
-				result[CommunePropertiesKeys.TopEtablissementsPrimaires] as string,
-			),
-			[CommunePropertiesKeys.NbEtablissementsParNiveauPotentielTotal]: JSON.parse(
-				result[CommunePropertiesKeys.NbEtablissementsParNiveauPotentielTotal] as string,
-			),
-			[CommunePropertiesKeys.NbEtablissementsParNiveauPotentielPrimaires]: JSON.parse(
-				result[CommunePropertiesKeys.NbEtablissementsParNiveauPotentielPrimaires] as string,
+			nb_etablissements_par_niveau_potentiel_primaires: JSON.parse(
+				result.nb_etablissements_par_niveau_potentiel_primaires as string,
 			),
 		} as Commune;
 	} catch (error) {
@@ -545,19 +532,13 @@ export async function fetchDepartementById(id: string): Promise<Departement | nu
 		// TODO: check if duckdb can do this
 		return {
 			...result,
-			[DepartementPropertiesKeys.TopEtablissementsTotal]: JSON.parse(
-				result[DepartementPropertiesKeys.TopEtablissementsTotal] as string,
+			top_etablissements_total: JSON.parse(result.top_etablissements_total as string),
+			top_etablissements_colleges: JSON.parse(result.top_etablissements_colleges as string),
+			nb_etablissements_par_niveau_potentiel_total: JSON.parse(
+				result.nb_etablissements_par_niveau_potentiel_total as string,
 			),
-			[DepartementPropertiesKeys.TopEtablissementsColleges]: JSON.parse(
-				result[DepartementPropertiesKeys.TopEtablissementsColleges] as string,
-			),
-			[DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielTotal]: JSON.parse(
-				result[DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielTotal] as string,
-			),
-			[DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielColleges]: JSON.parse(
-				result[
-					DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielColleges
-				] as string,
+			nb_etablissements_par_niveau_potentiel_colleges: JSON.parse(
+				result.nb_etablissements_par_niveau_potentiel_colleges as string,
 			),
 		} as Departement;
 	} catch (error) {
@@ -607,17 +588,13 @@ export async function fetchRegionById(id: string): Promise<Region | null> {
 		// TODO: check if duckdb can do this
 		return {
 			...result,
-			[RegionPropertiesKeys.TopEtablissementsTotal]: JSON.parse(
-				result[RegionPropertiesKeys.TopEtablissementsTotal] as string,
+			top_etablissements_total: JSON.parse(result.top_etablissements_total as string),
+			top_etablissements_lycees: JSON.parse(result.top_etablissements_lycees as string),
+			nb_etablissements_par_niveau_potentiel_total: JSON.parse(
+				result.nb_etablissements_par_niveau_potentiel_total as string,
 			),
-			[RegionPropertiesKeys.TopEtablissementsLycees]: JSON.parse(
-				result[RegionPropertiesKeys.TopEtablissementsLycees] as string,
-			),
-			[RegionPropertiesKeys.NbEtablissementsParNiveauPotentielTotal]: JSON.parse(
-				result[RegionPropertiesKeys.NbEtablissementsParNiveauPotentielTotal] as string,
-			),
-			[RegionPropertiesKeys.NbEtablissementsParNiveauPotentielLycees]: JSON.parse(
-				result[RegionPropertiesKeys.NbEtablissementsParNiveauPotentielLycees] as string,
+			nb_etablissements_par_niveau_potentiel_lycees: JSON.parse(
+				result.nb_etablissements_par_niveau_potentiel_lycees as string,
 			),
 		} as Region;
 	} catch (error) {
@@ -656,7 +633,7 @@ export async function fetchSearchResults(
 			FROM ${REF_CODE_POSTAL_TABLE} refCp
 			INNER JOIN ${SEARCH_VIEW_TABLE} sv ON sv.${SEARCH_VIEW_COLUMNS.Source} = 'communes' AND sv.${SEARCH_VIEW_COLUMNS.Id} = refCp.${REF_CODE_POSTAL_COLUMNS.CodeInsee}
 			WHERE refCp.${REF_CODE_POSTAL_COLUMNS.CodePostal} like $1
-			ORDER BY sv.${SearchPropertiesKeys.Libelle}
+			ORDER BY sv.${SEARCH_VIEW_MAPPING[SEARCH_VIEW_COLUMNS.Libelle]}
 			LIMIT $2;
 			`,
 			);

--- a/application/app/lib/db-mapping/communes.ts
+++ b/application/app/lib/db-mapping/communes.ts
@@ -1,6 +1,9 @@
-import { CommuneFeaturePropertiesKeys, CommunePropertiesKeys } from '../../models/communes';
+import { Commune, CommuneFeatureProperties } from '../../models/communes';
 
 export const COMMUNES_TABLE = 'communes';
+/**
+ * DB column names for the communes table.
+ */
 export const COMMUNES_COLUMNS = {
 	Id: 'code_commune',
 	Nom: 'nom_commune',
@@ -29,45 +32,52 @@ export const COMMUNES_COLUMNS = {
 	Geometry: 'geom',
 } as const;
 
-export const COMMUNES_MAPPING = {
-	[COMMUNES_COLUMNS.Id]: CommunePropertiesKeys.Id,
-	[COMMUNES_COLUMNS.Nom]: CommunePropertiesKeys.Nom,
-	[COMMUNES_COLUMNS.CodeDepartement]: CommunePropertiesKeys.CodeDepartement,
-	[COMMUNES_COLUMNS.LibelleDepartement]: CommunePropertiesKeys.LibelleDepartement,
-	[COMMUNES_COLUMNS.CodeRegion]: CommunePropertiesKeys.CodeRegion,
-	[COMMUNES_COLUMNS.LibelleRegion]: CommunePropertiesKeys.LibelleRegion,
-	[COMMUNES_COLUMNS.NbElevesTotal]: CommunePropertiesKeys.NbElevesTotal,
-	[COMMUNES_COLUMNS.NbElevesPrimaires]: CommunePropertiesKeys.NbElevesPrimaires,
-	[COMMUNES_COLUMNS.NbEtablissementsTotal]: CommunePropertiesKeys.NbEtablissementsTotal,
-	[COMMUNES_COLUMNS.NbEtablissementsPrimaires]: CommunePropertiesKeys.NbEtablissementsPrimaires,
-	[COMMUNES_COLUMNS.NbEtablissementsProtegesTotal]:
-		CommunePropertiesKeys.NbEtablissementsProtegesTotal,
-	[COMMUNES_COLUMNS.NbEtablissementsProtegesPrimaires]:
-		CommunePropertiesKeys.NbEtablissementsProtegesPrimaires,
-	[COMMUNES_COLUMNS.SurfaceExploitableMaxTotal]: CommunePropertiesKeys.SurfaceExploitableMaxTotal,
-	[COMMUNES_COLUMNS.SurfaceExploitableMaxPrimaires]:
-		CommunePropertiesKeys.SurfaceExploitableMaxPrimaires,
-	[COMMUNES_COLUMNS.PotentielSolaireTotal]: CommunePropertiesKeys.PotentielSolaireTotal,
-	[COMMUNES_COLUMNS.PotentielSolairePrimaires]: CommunePropertiesKeys.PotentielSolairePrimaires,
-	[COMMUNES_COLUMNS.PotentielNbFoyersTotal]: CommunePropertiesKeys.PotentielNbFoyersTotal,
-	[COMMUNES_COLUMNS.PotentielNbFoyersPrimaires]: CommunePropertiesKeys.PotentielNbFoyersPrimaires,
-	[COMMUNES_COLUMNS.TopEtablissementsTotal]: CommunePropertiesKeys.TopEtablissementsTotal,
-	[COMMUNES_COLUMNS.TopEtablissementsPrimaires]: CommunePropertiesKeys.TopEtablissementsPrimaires,
-	[COMMUNES_COLUMNS.NbEtablissementsParNiveauPotentielTotal]:
-		CommunePropertiesKeys.NbEtablissementsParNiveauPotentielTotal,
-	[COMMUNES_COLUMNS.NbEtablissementsParNiveauPotentielPrimaires]:
-		CommunePropertiesKeys.NbEtablissementsParNiveauPotentielPrimaires,
-} as const;
+type CommuneColumnValues = (typeof COMMUNES_COLUMNS)[keyof typeof COMMUNES_COLUMNS];
 
+/**
+ * Mapping of communes columns to Commune properties.
+ */
+export const COMMUNES_MAPPING = {
+	[COMMUNES_COLUMNS.Id]: 'code_commune',
+	[COMMUNES_COLUMNS.Nom]: 'nom_commune',
+	[COMMUNES_COLUMNS.CodeDepartement]: 'code_departement',
+	[COMMUNES_COLUMNS.LibelleDepartement]: 'libelle_departement',
+	[COMMUNES_COLUMNS.CodeRegion]: 'code_region',
+	[COMMUNES_COLUMNS.LibelleRegion]: 'libelle_region',
+	[COMMUNES_COLUMNS.NbElevesTotal]: 'nb_eleves_total',
+	[COMMUNES_COLUMNS.NbElevesPrimaires]: 'nb_eleves_primaires',
+	[COMMUNES_COLUMNS.NbEtablissementsTotal]: 'nb_etablissements_total',
+	[COMMUNES_COLUMNS.NbEtablissementsPrimaires]: 'nb_etablissements_primaires',
+	[COMMUNES_COLUMNS.NbEtablissementsProtegesTotal]: 'nb_etablissements_proteges_total',
+	[COMMUNES_COLUMNS.NbEtablissementsProtegesPrimaires]: 'nb_etablissements_proteges_primaires',
+	[COMMUNES_COLUMNS.SurfaceExploitableMaxTotal]: 'surface_exploitable_max_total',
+	[COMMUNES_COLUMNS.SurfaceExploitableMaxPrimaires]: 'surface_exploitable_max_primaires',
+	[COMMUNES_COLUMNS.PotentielSolaireTotal]: 'potentiel_solaire_total',
+	[COMMUNES_COLUMNS.PotentielSolairePrimaires]: 'potentiel_solaire_primaires',
+	[COMMUNES_COLUMNS.PotentielNbFoyersTotal]: 'potentiel_nb_foyers_total',
+	[COMMUNES_COLUMNS.PotentielNbFoyersPrimaires]: 'potentiel_nb_foyers_primaires',
+	[COMMUNES_COLUMNS.TopEtablissementsTotal]: 'top_etablissements_total',
+	[COMMUNES_COLUMNS.TopEtablissementsPrimaires]: 'top_etablissements_primaires',
+	[COMMUNES_COLUMNS.NbEtablissementsParNiveauPotentielTotal]:
+		'nb_etablissements_par_niveau_potentiel_total',
+	[COMMUNES_COLUMNS.NbEtablissementsParNiveauPotentielPrimaires]:
+		'nb_etablissements_par_niveau_potentiel_primaires',
+} as const satisfies Partial<{
+	[K in CommuneColumnValues]: keyof Commune;
+}>;
+
+/**
+ * Mapping of communes columns to CommuneFeatureProperties properties for GeoJSON.
+ */
 export const COMMUNES_GEOJSON_MAPPING = {
-	[COMMUNES_COLUMNS.Id]: CommuneFeaturePropertiesKeys.Id,
-	[COMMUNES_COLUMNS.Nom]: CommuneFeaturePropertiesKeys.Nom,
-	[COMMUNES_COLUMNS.CodeDepartement]: CommuneFeaturePropertiesKeys.CodeDepartement,
-	[COMMUNES_COLUMNS.CodeRegion]: CommuneFeaturePropertiesKeys.CodeRegion,
-	[COMMUNES_COLUMNS.PotentielSolaireTotal]: CommuneFeaturePropertiesKeys.PotentielSolaireTotal,
-	[COMMUNES_COLUMNS.PotentielSolaireLycees]: CommuneFeaturePropertiesKeys.PotentielSolaireLycees,
-	[COMMUNES_COLUMNS.PotentielSolaireColleges]:
-		CommuneFeaturePropertiesKeys.PotentielSolaireColleges,
-	[COMMUNES_COLUMNS.PotentielSolairePrimaires]:
-		CommuneFeaturePropertiesKeys.PotentielSolairePrimaires,
-} as const;
+	[COMMUNES_COLUMNS.Id]: 'code_commune',
+	[COMMUNES_COLUMNS.Nom]: 'nom_commune',
+	[COMMUNES_COLUMNS.CodeDepartement]: 'code_departement',
+	[COMMUNES_COLUMNS.CodeRegion]: 'code_region',
+	[COMMUNES_COLUMNS.PotentielSolaireTotal]: 'potentiel_solaire_total',
+	[COMMUNES_COLUMNS.PotentielSolaireLycees]: 'potentiel_solaire_lycees',
+	[COMMUNES_COLUMNS.PotentielSolaireColleges]: 'potentiel_solaire_colleges',
+	[COMMUNES_COLUMNS.PotentielSolairePrimaires]: 'potentiel_solaire_primaires',
+} as const satisfies Partial<{
+	[K in CommuneColumnValues]: keyof CommuneFeatureProperties;
+}>;

--- a/application/app/lib/db-mapping/departements.ts
+++ b/application/app/lib/db-mapping/departements.ts
@@ -1,9 +1,9 @@
-import {
-	DepartementFeaturePropertiesKeys,
-	DepartementPropertiesKeys,
-} from '../../models/departements';
+import { Departement, DepartementFeatureProperties } from '@/app/models/departements';
 
 export const DEPARTEMENTS_TABLE = 'departements';
+/**
+ * DB column names for the departements table.
+ */
 export const DEPARTEMENTS_COLUMNS = {
 	Id: 'code_departement',
 	Nom: 'libelle_departement',
@@ -30,49 +30,49 @@ export const DEPARTEMENTS_COLUMNS = {
 	Geometry: 'geom',
 } as const;
 
-export const DEPARTEMENTS_MAPPING = {
-	[DEPARTEMENTS_COLUMNS.Id]: DepartementPropertiesKeys.Id,
-	[DEPARTEMENTS_COLUMNS.Nom]: DepartementPropertiesKeys.Nom,
-	[DEPARTEMENTS_COLUMNS.CodeRegion]: DepartementPropertiesKeys.CodeRegion,
-	[DEPARTEMENTS_COLUMNS.LibelleRegion]: DepartementPropertiesKeys.LibelleRegion,
-	[DEPARTEMENTS_COLUMNS.NbElevesTotal]: DepartementPropertiesKeys.NbElevesTotal,
-	[DEPARTEMENTS_COLUMNS.NbElevesColleges]: DepartementPropertiesKeys.NbElevesColleges,
-	[DEPARTEMENTS_COLUMNS.NbEtablissementsTotal]: DepartementPropertiesKeys.NbEtablissementsTotal,
-	[DEPARTEMENTS_COLUMNS.NbEtablissementsColleges]:
-		DepartementPropertiesKeys.NbEtablissementsColleges,
-	[DEPARTEMENTS_COLUMNS.NbEtablissementsProtegesTotal]:
-		DepartementPropertiesKeys.NbEtablissementsProtegesTotal,
-	[DEPARTEMENTS_COLUMNS.NbEtablissementsProtegesColleges]:
-		DepartementPropertiesKeys.NbEtablissementsProtegesColleges,
-	[DEPARTEMENTS_COLUMNS.SurfaceExploitableMaxTotal]:
-		DepartementPropertiesKeys.SurfaceExploitableMaxTotal,
-	[DEPARTEMENTS_COLUMNS.SurfaceExploitableMaxColleges]:
-		DepartementPropertiesKeys.SurfaceExploitableMaxColleges,
-	[DEPARTEMENTS_COLUMNS.PotentielSolaireTotal]: DepartementPropertiesKeys.PotentielSolaireTotal,
-	[DEPARTEMENTS_COLUMNS.PotentielSolaireColleges]:
-		DepartementPropertiesKeys.PotentielSolaireColleges,
-	[DEPARTEMENTS_COLUMNS.PotentielNbFoyersTotal]: DepartementPropertiesKeys.PotentielNbFoyersTotal,
-	[DEPARTEMENTS_COLUMNS.PotentielNbFoyersColleges]:
-		DepartementPropertiesKeys.PotentielNbFoyersColleges,
-	[DEPARTEMENTS_COLUMNS.TopEtablissementsTotal]: DepartementPropertiesKeys.TopEtablissementsTotal,
-	[DEPARTEMENTS_COLUMNS.TopEtablissementsColleges]:
-		DepartementPropertiesKeys.TopEtablissementsColleges,
-	[DEPARTEMENTS_COLUMNS.NbEtablissementsParNiveauPotentielTotal]:
-		DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielTotal,
-	[DEPARTEMENTS_COLUMNS.NbEtablissementsParNiveauPotentielColleges]:
-		DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielColleges,
-} as const;
+type DepartementColumnValues = (typeof DEPARTEMENTS_COLUMNS)[keyof typeof DEPARTEMENTS_COLUMNS];
 
+/**
+ * Mapping of departements columns to Departement properties.
+ */
+export const DEPARTEMENTS_MAPPING = {
+	[DEPARTEMENTS_COLUMNS.Id]: 'code_departement',
+	[DEPARTEMENTS_COLUMNS.Nom]: 'libelle_departement',
+	[DEPARTEMENTS_COLUMNS.CodeRegion]: 'code_region',
+	[DEPARTEMENTS_COLUMNS.LibelleRegion]: 'libelle_region',
+	[DEPARTEMENTS_COLUMNS.NbElevesTotal]: 'nb_eleves_total',
+	[DEPARTEMENTS_COLUMNS.NbElevesColleges]: 'nb_eleves_colleges',
+	[DEPARTEMENTS_COLUMNS.NbEtablissementsTotal]: 'nb_etablissements_total',
+	[DEPARTEMENTS_COLUMNS.NbEtablissementsColleges]: 'nb_etablissements_colleges',
+	[DEPARTEMENTS_COLUMNS.NbEtablissementsProtegesTotal]: 'nb_etablissements_proteges_total',
+	[DEPARTEMENTS_COLUMNS.NbEtablissementsProtegesColleges]: 'nb_etablissements_proteges_colleges',
+	[DEPARTEMENTS_COLUMNS.SurfaceExploitableMaxTotal]: 'surface_exploitable_max_total',
+	[DEPARTEMENTS_COLUMNS.SurfaceExploitableMaxColleges]: 'surface_exploitable_max_colleges',
+	[DEPARTEMENTS_COLUMNS.PotentielSolaireTotal]: 'potentiel_solaire_total',
+	[DEPARTEMENTS_COLUMNS.PotentielSolaireColleges]: 'potentiel_solaire_colleges',
+	[DEPARTEMENTS_COLUMNS.PotentielNbFoyersTotal]: 'potentiel_nb_foyers_total',
+	[DEPARTEMENTS_COLUMNS.PotentielNbFoyersColleges]: 'potentiel_nb_foyers_colleges',
+	[DEPARTEMENTS_COLUMNS.TopEtablissementsTotal]: 'top_etablissements_total',
+	[DEPARTEMENTS_COLUMNS.TopEtablissementsColleges]: 'top_etablissements_colleges',
+	[DEPARTEMENTS_COLUMNS.NbEtablissementsParNiveauPotentielTotal]:
+		'nb_etablissements_par_niveau_potentiel_total',
+	[DEPARTEMENTS_COLUMNS.NbEtablissementsParNiveauPotentielColleges]:
+		'nb_etablissements_par_niveau_potentiel_colleges',
+} as const satisfies Partial<{
+	[K in DepartementColumnValues]: keyof Departement;
+}>;
+
+/**
+ * Mapping of departements columns to DepartementFeatureProperties properties for GeoJSON.
+ */
 export const DEPARTEMENTS_GEOJSON_MAPPING = {
-	[DEPARTEMENTS_COLUMNS.Id]: DepartementFeaturePropertiesKeys.Id,
-	[DEPARTEMENTS_COLUMNS.Nom]: DepartementFeaturePropertiesKeys.Nom,
-	[DEPARTEMENTS_COLUMNS.CodeRegion]: DepartementFeaturePropertiesKeys.CodeRegion,
-	[DEPARTEMENTS_COLUMNS.PotentielSolaireTotal]:
-		DepartementFeaturePropertiesKeys.PotentielSolaireTotal,
-	[DEPARTEMENTS_COLUMNS.PotentielSolaireLycees]:
-		DepartementFeaturePropertiesKeys.PotentielSolaireLycees,
-	[DEPARTEMENTS_COLUMNS.PotentielSolaireColleges]:
-		DepartementFeaturePropertiesKeys.PotentielSolaireColleges,
-	[DEPARTEMENTS_COLUMNS.PotentielSolairePrimaires]:
-		DepartementFeaturePropertiesKeys.PotentielSolairePrimaires,
-} as const;
+	[DEPARTEMENTS_COLUMNS.Id]: 'code_departement',
+	[DEPARTEMENTS_COLUMNS.Nom]: 'libelle_departement',
+	[DEPARTEMENTS_COLUMNS.CodeRegion]: 'code_region',
+	[DEPARTEMENTS_COLUMNS.PotentielSolaireTotal]: 'potentiel_solaire_total',
+	[DEPARTEMENTS_COLUMNS.PotentielSolaireLycees]: 'potentiel_solaire_lycees',
+	[DEPARTEMENTS_COLUMNS.PotentielSolaireColleges]: 'potentiel_solaire_colleges',
+	[DEPARTEMENTS_COLUMNS.PotentielSolairePrimaires]: 'potentiel_solaire_primaires',
+} as const satisfies Partial<{
+	[K in DepartementColumnValues]: keyof DepartementFeatureProperties;
+}>;

--- a/application/app/lib/db-mapping/etablissements.ts
+++ b/application/app/lib/db-mapping/etablissements.ts
@@ -1,10 +1,10 @@
-import {
-	EtablissementFeaturePropertiesKeys,
-	EtablissementPropertiesKeys,
-} from '../../models/etablissements';
+import { Etablissement, EtablissementFeatureProperties } from '@/app/models/etablissements';
 
 export const ETABLISSEMENTS_TABLE = 'etablissements';
 
+/**
+ * DB column names for the etablissements table.
+ */
 export const ETABLISSEMENTS_COLUMNS = {
 	Id: 'identifiant_de_l_etablissement',
 	Nom: 'nom_etablissement',
@@ -29,36 +29,48 @@ export const ETABLISSEMENTS_COLUMNS = {
 	Geometry: 'geom',
 } as const;
 
-export const ETABLISSEMENTS_MAPPING = {
-	[ETABLISSEMENTS_COLUMNS.Id]: EtablissementPropertiesKeys.Id,
-	[ETABLISSEMENTS_COLUMNS.Nom]: EtablissementPropertiesKeys.Nom,
-	[ETABLISSEMENTS_COLUMNS.Type]: EtablissementPropertiesKeys.Type,
-	[ETABLISSEMENTS_COLUMNS.LibelleNature]: EtablissementPropertiesKeys.LibelleNature,
-	[ETABLISSEMENTS_COLUMNS.CodeCommune]: EtablissementPropertiesKeys.CodeCommune,
-	[ETABLISSEMENTS_COLUMNS.NomCommune]: EtablissementPropertiesKeys.NomCommune,
-	[ETABLISSEMENTS_COLUMNS.CodeDepartement]: EtablissementPropertiesKeys.CodeDepartement,
-	[ETABLISSEMENTS_COLUMNS.LibelleDepartement]: EtablissementPropertiesKeys.LibelleDepartement,
-	[ETABLISSEMENTS_COLUMNS.CodeRegion]: EtablissementPropertiesKeys.CodeRegion,
-	[ETABLISSEMENTS_COLUMNS.LibelleRegion]: EtablissementPropertiesKeys.LibelleRegion,
-	[ETABLISSEMENTS_COLUMNS.SurfaceExploitableMax]:
-		EtablissementPropertiesKeys.SurfaceExploitableMax,
-	[ETABLISSEMENTS_COLUMNS.PotentielSolaire]: EtablissementPropertiesKeys.PotentielSolaire,
-	[ETABLISSEMENTS_COLUMNS.PotentielNbFoyers]: EtablissementPropertiesKeys.PotentielNbFoyers,
-	[ETABLISSEMENTS_COLUMNS.Protection]: EtablissementPropertiesKeys.Protection,
-	[ETABLISSEMENTS_COLUMNS.NbEleves]: EtablissementPropertiesKeys.NbEleves,
-	[ETABLISSEMENTS_COLUMNS.Adresse1]: EtablissementPropertiesKeys.Adresse1,
-	[ETABLISSEMENTS_COLUMNS.Adresse2]: EtablissementPropertiesKeys.Adresse2,
-	[ETABLISSEMENTS_COLUMNS.Adresse3]: EtablissementPropertiesKeys.Adresse3,
-	[ETABLISSEMENTS_COLUMNS.CodePostal]: EtablissementPropertiesKeys.CodePostal,
-	[ETABLISSEMENTS_COLUMNS.NiveauPotentiel]: EtablissementPropertiesKeys.NiveauPotentiel,
-} as const;
+type EtablissementColumnValues =
+	(typeof ETABLISSEMENTS_COLUMNS)[keyof typeof ETABLISSEMENTS_COLUMNS];
 
+/**
+ * Mapping of etablissements columns to Etablissement properties.
+ */
+export const ETABLISSEMENTS_MAPPING = {
+	[ETABLISSEMENTS_COLUMNS.Id]: 'identifiant_de_l_etablissement',
+	[ETABLISSEMENTS_COLUMNS.Nom]: 'nom_etablissement',
+	[ETABLISSEMENTS_COLUMNS.Type]: 'type_etablissement',
+	[ETABLISSEMENTS_COLUMNS.LibelleNature]: 'libelle_nature',
+	[ETABLISSEMENTS_COLUMNS.CodeCommune]: 'code_commune',
+	[ETABLISSEMENTS_COLUMNS.NomCommune]: 'nom_commune',
+	[ETABLISSEMENTS_COLUMNS.CodeDepartement]: 'code_departement',
+	[ETABLISSEMENTS_COLUMNS.LibelleDepartement]: 'libelle_departement',
+	[ETABLISSEMENTS_COLUMNS.CodeRegion]: 'code_region',
+	[ETABLISSEMENTS_COLUMNS.LibelleRegion]: 'libelle_region',
+	[ETABLISSEMENTS_COLUMNS.SurfaceExploitableMax]: 'surface_exploitable_max',
+	[ETABLISSEMENTS_COLUMNS.PotentielSolaire]: 'potentiel_solaire',
+	[ETABLISSEMENTS_COLUMNS.PotentielNbFoyers]: 'potentiel_nb_foyers',
+	[ETABLISSEMENTS_COLUMNS.Protection]: 'protection',
+	[ETABLISSEMENTS_COLUMNS.NbEleves]: 'nb_eleves',
+	[ETABLISSEMENTS_COLUMNS.Adresse1]: 'adresse_1',
+	[ETABLISSEMENTS_COLUMNS.Adresse2]: 'adresse_2',
+	[ETABLISSEMENTS_COLUMNS.Adresse3]: 'adresse_3',
+	[ETABLISSEMENTS_COLUMNS.CodePostal]: 'code_postal',
+	[ETABLISSEMENTS_COLUMNS.NiveauPotentiel]: 'niveau_potentiel',
+} as const satisfies Partial<{
+	[K in EtablissementColumnValues]: keyof Etablissement;
+}>;
+
+/**
+ * Mapping of etablissements columns to EtablissementFeatureProperties properties for GeoJSON.
+ */
 export const ETABLISSEMENTS_GEOJSON_MAPPING = {
-	[ETABLISSEMENTS_COLUMNS.Id]: EtablissementFeaturePropertiesKeys.Id,
-	[ETABLISSEMENTS_COLUMNS.Nom]: EtablissementFeaturePropertiesKeys.Nom,
-	[ETABLISSEMENTS_COLUMNS.CodeCommune]: EtablissementFeaturePropertiesKeys.CodeCommune,
-	[ETABLISSEMENTS_COLUMNS.CodeDepartement]: EtablissementFeaturePropertiesKeys.CodeDepartement,
-	[ETABLISSEMENTS_COLUMNS.CodeRegion]: EtablissementFeaturePropertiesKeys.CodeRegion,
-	[ETABLISSEMENTS_COLUMNS.PotentielSolaire]: EtablissementFeaturePropertiesKeys.PotentielSolaire,
-	[ETABLISSEMENTS_COLUMNS.Protection]: EtablissementFeaturePropertiesKeys.Protection,
-} as const;
+	[ETABLISSEMENTS_COLUMNS.Id]: 'identifiant_de_l_etablissement',
+	[ETABLISSEMENTS_COLUMNS.Nom]: 'nom_etablissement',
+	[ETABLISSEMENTS_COLUMNS.CodeCommune]: 'code_commune',
+	[ETABLISSEMENTS_COLUMNS.CodeDepartement]: 'code_departement',
+	[ETABLISSEMENTS_COLUMNS.CodeRegion]: 'code_region',
+	[ETABLISSEMENTS_COLUMNS.PotentielSolaire]: 'potentiel_solaire',
+	[ETABLISSEMENTS_COLUMNS.Protection]: 'protection',
+} as const satisfies Partial<{
+	[K in EtablissementColumnValues]: keyof EtablissementFeatureProperties;
+}>;

--- a/application/app/lib/db-mapping/regions.ts
+++ b/application/app/lib/db-mapping/regions.ts
@@ -1,6 +1,9 @@
-import { RegionFeaturePropertiesKeys, RegionPropertiesKeys } from '../../models/regions';
+import { Region, RegionFeatureProperties } from '../../models/regions';
 
 export const REGIONS_TABLE = 'regions';
+/**
+ * DB column names for the regions table.
+ */
 export const REGIONS_COLUMNS = {
 	Id: 'code_region',
 	Nom: 'libelle_region',
@@ -24,38 +27,44 @@ export const REGIONS_COLUMNS = {
 	NbEtablissementsParNiveauPotentielLycees: 'nb_etablissements_par_niveau_potentiel_lycees',
 	Geometry: 'geom',
 } as const;
-export const REGIONS_MAPPING = {
-	[REGIONS_COLUMNS.Id]: RegionPropertiesKeys.Id,
-	[REGIONS_COLUMNS.Nom]: RegionPropertiesKeys.Nom,
-	[REGIONS_COLUMNS.NbElevesTotal]: RegionPropertiesKeys.NbElevesTotal,
-	[REGIONS_COLUMNS.NbElevesLycees]: RegionPropertiesKeys.NbElevesLycees,
-	[REGIONS_COLUMNS.NbEtablissementsTotal]: RegionPropertiesKeys.NbEtablissementsTotal,
-	[REGIONS_COLUMNS.NbEtablissementsLycees]: RegionPropertiesKeys.NbEtablissementsLycees,
-	[REGIONS_COLUMNS.NbEtablissementsProtegesTotal]:
-		RegionPropertiesKeys.NbEtablissementsProtegesTotal,
-	[REGIONS_COLUMNS.NbEtablissementsProtegesLycees]:
-		RegionPropertiesKeys.NbEtablissementsProtegesLycees,
-	[REGIONS_COLUMNS.SurfaceExploitableMaxTotal]: RegionPropertiesKeys.SurfaceExploitableMaxTotal,
-	[REGIONS_COLUMNS.SurfaceExploitableMaxLycees]: RegionPropertiesKeys.SurfaceExploitableMaxLycees,
-	[REGIONS_COLUMNS.PotentielSolaireTotal]: RegionPropertiesKeys.PotentielSolaireTotal,
-	[REGIONS_COLUMNS.PotentielSolaireLycees]: RegionPropertiesKeys.PotentielSolaireLycees,
-	[REGIONS_COLUMNS.PotentielNbFoyersTotal]: RegionPropertiesKeys.PotentielNbFoyersTotal,
-	[REGIONS_COLUMNS.PotentielNbFoyersLycees]: RegionPropertiesKeys.PotentielNbFoyersLycees,
-	[REGIONS_COLUMNS.TopEtablissementsTotal]: RegionPropertiesKeys.TopEtablissementsTotal,
-	[REGIONS_COLUMNS.TopEtablissementsLycees]: RegionPropertiesKeys.TopEtablissementsLycees,
-	[REGIONS_COLUMNS.NbEtablissementsParNiveauPotentielTotal]:
-		RegionPropertiesKeys.NbEtablissementsParNiveauPotentielTotal,
-	[REGIONS_COLUMNS.NbEtablissementsParNiveauPotentielLycees]:
-		RegionPropertiesKeys.NbEtablissementsParNiveauPotentielLycees,
-} as const;
 
+type RegionColumnValues = (typeof REGIONS_COLUMNS)[keyof typeof REGIONS_COLUMNS];
+
+export const REGIONS_MAPPING = {
+	[REGIONS_COLUMNS.Id]: 'code_region',
+	[REGIONS_COLUMNS.Nom]: 'libelle_region',
+	[REGIONS_COLUMNS.NbElevesTotal]: 'nb_eleves_total',
+	[REGIONS_COLUMNS.NbElevesLycees]: 'nb_eleves_lycees',
+	[REGIONS_COLUMNS.NbEtablissementsTotal]: 'nb_etablissements_total',
+	[REGIONS_COLUMNS.NbEtablissementsLycees]: 'nb_etablissements_lycees',
+	[REGIONS_COLUMNS.NbEtablissementsProtegesTotal]: 'nb_etablissements_proteges_total',
+	[REGIONS_COLUMNS.NbEtablissementsProtegesLycees]: 'nb_etablissements_proteges_lycees',
+	[REGIONS_COLUMNS.SurfaceExploitableMaxTotal]: 'surface_exploitable_max_total',
+	[REGIONS_COLUMNS.SurfaceExploitableMaxLycees]: 'surface_exploitable_max_lycees',
+	[REGIONS_COLUMNS.PotentielSolaireTotal]: 'potentiel_solaire_total',
+	[REGIONS_COLUMNS.PotentielSolaireLycees]: 'potentiel_solaire_lycees',
+	[REGIONS_COLUMNS.PotentielNbFoyersTotal]: 'potentiel_nb_foyers_total',
+	[REGIONS_COLUMNS.PotentielNbFoyersLycees]: 'potentiel_nb_foyers_lycees',
+	[REGIONS_COLUMNS.TopEtablissementsTotal]: 'top_etablissements_total',
+	[REGIONS_COLUMNS.TopEtablissementsLycees]: 'top_etablissements_lycees',
+	[REGIONS_COLUMNS.NbEtablissementsParNiveauPotentielTotal]:
+		'nb_etablissements_par_niveau_potentiel_total',
+	[REGIONS_COLUMNS.NbEtablissementsParNiveauPotentielLycees]:
+		'nb_etablissements_par_niveau_potentiel_lycees',
+} as const satisfies Partial<{
+	[K in RegionColumnValues]: keyof Region;
+}>;
+
+/**
+ * Mapping of regions columns to RegionFeatureProperties properties for GeoJSON.
+ */
 export const REGIONS_GEOJSON_MAPPING = {
-	[REGIONS_COLUMNS.Id]: RegionFeaturePropertiesKeys.Id,
-	[REGIONS_COLUMNS.Nom]: RegionFeaturePropertiesKeys.Nom,
-	[REGIONS_COLUMNS.PotentielSolaireTotal]: RegionFeaturePropertiesKeys.PotentielSolaireTotal,
-	[REGIONS_COLUMNS.PotentielSolaireLycees]: RegionFeaturePropertiesKeys.PotentielSolaireLycees,
-	[REGIONS_COLUMNS.PotentielSolaireColleges]:
-		RegionFeaturePropertiesKeys.PotentielSolaireColleges,
-	[REGIONS_COLUMNS.PotentielSolairePrimaires]:
-		RegionFeaturePropertiesKeys.PotentielSolairePrimaires,
-} as const;
+	[REGIONS_COLUMNS.Id]: 'code_region',
+	[REGIONS_COLUMNS.Nom]: 'libelle_region',
+	[REGIONS_COLUMNS.PotentielSolaireTotal]: 'potentiel_solaire_total',
+	[REGIONS_COLUMNS.PotentielSolaireLycees]: 'potentiel_solaire_lycees',
+	[REGIONS_COLUMNS.PotentielSolaireColleges]: 'potentiel_solaire_colleges',
+	[REGIONS_COLUMNS.PotentielSolairePrimaires]: 'potentiel_solaire_primaires',
+} as const satisfies Partial<{
+	[K in RegionColumnValues]: keyof RegionFeatureProperties;
+}>;

--- a/application/app/lib/db-mapping/searchView.ts
+++ b/application/app/lib/db-mapping/searchView.ts
@@ -1,6 +1,9 @@
-import { SearchPropertiesKeys } from '../../models/search';
+import { SearchResult } from '../../models/search';
 
 export const SEARCH_VIEW_TABLE = 'search_view';
+/**
+ * DB column names for the search view.
+ */
 export const SEARCH_VIEW_COLUMNS = {
 	Source: 'source_table',
 	Id: 'id',
@@ -14,20 +17,24 @@ export const SEARCH_VIEW_COLUMNS = {
 	ExtraDataCodeCommune: 'code_commune',
 } as const;
 
+type SearchColumnValues = (typeof SEARCH_VIEW_COLUMNS)[keyof typeof SEARCH_VIEW_COLUMNS];
+
+/**
+ * Mapping of search view columns to SearchResult properties.
+ */
 export const SEARCH_VIEW_MAPPING = {
-	[SEARCH_VIEW_COLUMNS.Source]: SearchPropertiesKeys.Source,
-	[SEARCH_VIEW_COLUMNS.Id]: SearchPropertiesKeys.Id,
-	[SEARCH_VIEW_COLUMNS.Libelle]: SearchPropertiesKeys.Libelle,
-	[SEARCH_VIEW_COLUMNS.ExtraData]: SearchPropertiesKeys.ExtraData,
-	[SEARCH_VIEW_COLUMNS.ExtraDataNomCommune]: SearchPropertiesKeys.ExtraDataNomCommune,
-	[SEARCH_VIEW_COLUMNS.ExtraDataCodePostal]: SearchPropertiesKeys.ExtraDataCodePostal,
-	[SEARCH_VIEW_COLUMNS.ExtraDataCodeRegion]: SearchPropertiesKeys.ExtraDataCodeRegion,
-	[SEARCH_VIEW_COLUMNS.ExtraDataCodeDepartement]: SearchPropertiesKeys.ExtraDataCodeDepartement,
-	[SEARCH_VIEW_COLUMNS.ExtraDataCodeCommune]: SearchPropertiesKeys.ExtraDataCodeCommune,
-} as const;
-export const SEARCH_VIEW_SANITIZED_LIBELLE_COLUMN = 'sanitized_libelle';
+	[SEARCH_VIEW_COLUMNS.Source]: 'source',
+	[SEARCH_VIEW_COLUMNS.Id]: 'id',
+	[SEARCH_VIEW_COLUMNS.Libelle]: 'libelle',
+	[SEARCH_VIEW_COLUMNS.ExtraData]: 'extra_data',
+} as const satisfies Partial<{
+	[K in SearchColumnValues]: keyof SearchResult;
+}>;
 
 export const REF_CODE_POSTAL_TABLE = 'ref_code_postal';
+/**
+ * DB column names for the ref_code_postal table.
+ */
 export const REF_CODE_POSTAL_COLUMNS = {
 	CodeInsee: 'code_insee',
 	CodePostal: 'code_postal',

--- a/application/app/models/common.ts
+++ b/application/app/models/common.ts
@@ -8,10 +8,3 @@ export const NIVEAUX_POTENTIELS = [
 export type NiveauPotentiel = (typeof NIVEAUX_POTENTIELS)[number]['code'];
 
 export type NbEtablissementsByNiveauPotentiel = Record<NiveauPotentiel, number>;
-
-export const ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY = {
-	TOTAL: 'potentiel_solaire_total',
-	LYCEES: 'potentiel_solaire_lycees',
-	COLLEGES: 'potentiel_solaire_colleges',
-	PRIMAIRES: 'potentiel_solaire_primaires',
-} as const;

--- a/application/app/models/communes.ts
+++ b/application/app/models/communes.ts
@@ -1,85 +1,41 @@
-import { NbEtablissementsByNiveauPotentiel, ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY } from './common';
+import { NbEtablissementsByNiveauPotentiel } from './common';
 import { TopEtablissement } from './etablissements';
 
-/**
- * List of the Commune type properties.
- */
-//TODO: change values to camelCase after merge #190
-export const CommunePropertiesKeys = {
-	Id: 'code_commune',
-	Nom: 'nom_commune',
-	CodeDepartement: 'code_departement',
-	LibelleDepartement: 'libelle_departement',
-	CodeRegion: 'code_region',
-	LibelleRegion: 'libelle_region',
-	NbElevesTotal: 'nb_eleves_total',
-	NbElevesPrimaires: 'nb_eleves_primaires',
-	NbEtablissementsTotal: 'nb_etablissements_total',
-	NbEtablissementsPrimaires: 'nb_etablissements_primaires',
-	NbEtablissementsProtegesTotal: 'nb_etablissements_proteges_total',
-	NbEtablissementsProtegesPrimaires: 'nb_etablissements_proteges_primaires',
-	SurfaceExploitableMaxTotal: 'surface_exploitable_max_total',
-	SurfaceExploitableMaxPrimaires: 'surface_exploitable_max_primaires',
-	PotentielSolaireTotal: 'potentiel_solaire_total',
-	PotentielSolairePrimaires: 'potentiel_solaire_primaires',
-	PotentielNbFoyersTotal: 'potentiel_nb_foyers_total',
-	PotentielNbFoyersPrimaires: 'potentiel_nb_foyers_primaires',
-	TopEtablissementsTotal: 'top_etablissements_total',
-	TopEtablissementsPrimaires: 'top_etablissements_primaires',
-	NbEtablissementsParNiveauPotentielTotal: 'nb_etablissements_par_niveau_potentiel_total',
-	NbEtablissementsParNiveauPotentielPrimaires: 'nb_etablissements_par_niveau_potentiel_primaires',
-} as const;
-
 export type Commune = {
-	[CommunePropertiesKeys.Id]: string;
-	[CommunePropertiesKeys.Nom]: string;
-	[CommunePropertiesKeys.CodeDepartement]: string;
-	[CommunePropertiesKeys.LibelleDepartement]: string;
-	[CommunePropertiesKeys.CodeRegion]: string;
-	[CommunePropertiesKeys.LibelleRegion]: string;
-	[CommunePropertiesKeys.NbElevesTotal]: number;
-	[CommunePropertiesKeys.NbElevesPrimaires]: number;
-	[CommunePropertiesKeys.NbEtablissementsTotal]: number;
-	[CommunePropertiesKeys.NbEtablissementsPrimaires]: number;
-	[CommunePropertiesKeys.NbEtablissementsProtegesTotal]: number;
-	[CommunePropertiesKeys.NbEtablissementsProtegesPrimaires]: number;
-	[CommunePropertiesKeys.SurfaceExploitableMaxTotal]: number;
-	[CommunePropertiesKeys.SurfaceExploitableMaxPrimaires]: number;
-	[CommunePropertiesKeys.PotentielSolaireTotal]: number;
-	[CommunePropertiesKeys.PotentielSolairePrimaires]: number;
-	[CommunePropertiesKeys.PotentielNbFoyersTotal]: number;
-	[CommunePropertiesKeys.PotentielNbFoyersPrimaires]: number;
-	[CommunePropertiesKeys.TopEtablissementsTotal]: Array<TopEtablissement>;
-	[CommunePropertiesKeys.TopEtablissementsPrimaires]: Array<TopEtablissement>;
-	[CommunePropertiesKeys.NbEtablissementsParNiveauPotentielTotal]: NbEtablissementsByNiveauPotentiel;
-	[CommunePropertiesKeys.NbEtablissementsParNiveauPotentielPrimaires]: NbEtablissementsByNiveauPotentiel;
+	code_commune: string;
+	nom_commune: string;
+	code_departement: string;
+	libelle_departement: string;
+	code_region: string;
+	libelle_region: string;
+	nb_eleves_total: number;
+	nb_eleves_primaires: number;
+	nb_etablissements_total: number;
+	nb_etablissements_primaires: number;
+	nb_etablissements_proteges_total: number;
+	nb_etablissements_proteges_primaires: number;
+	surface_exploitable_max_total: number;
+	surface_exploitable_max_primaires: number;
+	potentiel_solaire_total: number;
+	potentiel_solaire_primaires: number;
+	potentiel_nb_foyers_total: number;
+	potentiel_nb_foyers_primaires: number;
+	top_etablissements_total: Array<TopEtablissement>;
+	top_etablissements_primaires: Array<TopEtablissement>;
+	nb_etablissements_par_niveau_potentiel_total: NbEtablissementsByNiveauPotentiel;
+	nb_etablissements_par_niveau_potentiel_primaires: NbEtablissementsByNiveauPotentiel;
 };
 
 // --- GeoJSON ----
-
-/**
- * List of the Commune Feature type properties.
- */
-export const CommuneFeaturePropertiesKeys = {
-	Id: 'code_commune',
-	Nom: 'nom_commune',
-	CodeDepartement: 'code_departement',
-	CodeRegion: 'code_region',
-	PotentielSolaireTotal: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.TOTAL,
-	PotentielSolaireLycees: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.LYCEES,
-	PotentielSolaireColleges: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.COLLEGES,
-	PotentielSolairePrimaires: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.PRIMAIRES,
-} as const;
-
 export interface CommuneFeatureProperties {
-	[CommuneFeaturePropertiesKeys.Id]: string;
-	[CommuneFeaturePropertiesKeys.Nom]: string;
-	[CommuneFeaturePropertiesKeys.CodeDepartement]: string;
-	[CommuneFeaturePropertiesKeys.CodeRegion]: string;
-	[CommuneFeaturePropertiesKeys.PotentielSolaireTotal]: number;
-	[CommuneFeaturePropertiesKeys.PotentielSolaireLycees]: number;
-	[CommuneFeaturePropertiesKeys.PotentielSolaireColleges]: number;
-	[CommuneFeaturePropertiesKeys.PotentielSolairePrimaires]: number;
+	code_commune: string;
+	nom_commune: string;
+	code_departement: string;
+	code_region: string;
+	potentiel_solaire_total: number;
+	potentiel_solaire_lycees: number;
+	potentiel_solaire_colleges: number;
+	potentiel_solaire_primaires: number;
 }
 export type CommuneFeature = CommunesGeoJSON['features'][number];
 
@@ -87,3 +43,6 @@ export type CommunesGeoJSON = GeoJSON.FeatureCollection<
 	GeoJSON.Polygon | GeoJSON.MultiPolygon,
 	CommuneFeatureProperties
 >;
+
+// Reference keys for proper access with maplibre layer properties
+export const COMMUNE_GEOJSON_KEY_NOM: keyof CommuneFeatureProperties = 'nom_commune';

--- a/application/app/models/departements.ts
+++ b/application/app/models/departements.ts
@@ -1,78 +1,38 @@
-import { NbEtablissementsByNiveauPotentiel, ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY } from './common';
+import { NbEtablissementsByNiveauPotentiel } from './common';
 import { TopEtablissement } from './etablissements';
 
-/**
- * List of the Departement type properties.
- */
-//TODO: change values to camelCase after merge #190
-export const DepartementPropertiesKeys = {
-	Id: 'code_departement',
-	Nom: 'libelle_departement',
-	CodeRegion: 'code_region',
-	LibelleRegion: 'libelle_region',
-	NbElevesTotal: 'nb_eleves_total',
-	NbElevesColleges: 'nb_eleves_colleges',
-	NbEtablissementsTotal: 'nb_etablissements_total',
-	NbEtablissementsColleges: 'nb_etablissements_colleges',
-	NbEtablissementsProtegesTotal: 'nb_etablissements_proteges_total',
-	NbEtablissementsProtegesColleges: 'nb_etablissements_proteges_colleges',
-	SurfaceExploitableMaxTotal: 'surface_exploitable_max_total',
-	SurfaceExploitableMaxColleges: 'surface_exploitable_max_colleges',
-	PotentielSolaireTotal: 'potentiel_solaire_total',
-	PotentielSolaireColleges: 'potentiel_solaire_colleges',
-	PotentielNbFoyersTotal: 'potentiel_nb_foyers_total',
-	PotentielNbFoyersColleges: 'potentiel_nb_foyers_colleges',
-	TopEtablissementsTotal: 'top_etablissements_total',
-	TopEtablissementsColleges: 'top_etablissements_colleges',
-	NbEtablissementsParNiveauPotentielTotal: 'nb_etablissements_par_niveau_potentiel_total',
-	NbEtablissementsParNiveauPotentielColleges: 'nb_etablissements_par_niveau_potentiel_colleges',
-} as const;
-
 export type Departement = {
-	[DepartementPropertiesKeys.Id]: string;
-	[DepartementPropertiesKeys.Nom]: string;
-	[DepartementPropertiesKeys.CodeRegion]: string;
-	[DepartementPropertiesKeys.LibelleRegion]: string;
-	[DepartementPropertiesKeys.NbElevesTotal]: number;
-	[DepartementPropertiesKeys.NbElevesColleges]: number;
-	[DepartementPropertiesKeys.NbEtablissementsTotal]: number;
-	[DepartementPropertiesKeys.NbEtablissementsColleges]: number;
-	[DepartementPropertiesKeys.NbEtablissementsProtegesTotal]: number;
-	[DepartementPropertiesKeys.NbEtablissementsProtegesColleges]: number;
-	[DepartementPropertiesKeys.SurfaceExploitableMaxTotal]: number;
-	[DepartementPropertiesKeys.SurfaceExploitableMaxColleges]: number;
-	[DepartementPropertiesKeys.PotentielSolaireTotal]: number;
-	[DepartementPropertiesKeys.PotentielSolaireColleges]: number;
-	[DepartementPropertiesKeys.PotentielNbFoyersTotal]: number;
-	[DepartementPropertiesKeys.PotentielNbFoyersColleges]: number;
-	[DepartementPropertiesKeys.TopEtablissementsTotal]: Array<TopEtablissement>;
-	[DepartementPropertiesKeys.TopEtablissementsColleges]: Array<TopEtablissement>;
-	[DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielTotal]: NbEtablissementsByNiveauPotentiel;
-	[DepartementPropertiesKeys.NbEtablissementsParNiveauPotentielColleges]: NbEtablissementsByNiveauPotentiel;
+	code_departement: string;
+	libelle_departement: string;
+	code_region: string;
+	libelle_region: string;
+	nb_eleves_total: number;
+	nb_eleves_colleges: number;
+	nb_etablissements_total: number;
+	nb_etablissements_colleges: number;
+	nb_etablissements_proteges_total: number;
+	nb_etablissements_proteges_colleges: number;
+	surface_exploitable_max_total: number;
+	surface_exploitable_max_colleges: number;
+	potentiel_solaire_total: number;
+	potentiel_solaire_colleges: number;
+	potentiel_nb_foyers_total: number;
+	potentiel_nb_foyers_colleges: number;
+	top_etablissements_total: Array<TopEtablissement>;
+	top_etablissements_colleges: Array<TopEtablissement>;
+	nb_etablissements_par_niveau_potentiel_total: NbEtablissementsByNiveauPotentiel;
+	nb_etablissements_par_niveau_potentiel_colleges: NbEtablissementsByNiveauPotentiel;
 };
 
 // ---- GeoJSON ----
-/**
- * List of the Departement Feature type properties.
- */
-export const DepartementFeaturePropertiesKeys = {
-	Id: 'code_departement',
-	Nom: 'libelle_departement',
-	CodeRegion: 'code_region',
-	PotentielSolaireTotal: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.TOTAL,
-	PotentielSolaireLycees: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.LYCEES,
-	PotentielSolaireColleges: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.COLLEGES,
-	PotentielSolairePrimaires: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.PRIMAIRES,
-} as const;
-
 export interface DepartementFeatureProperties {
-	[DepartementFeaturePropertiesKeys.Id]: string;
-	[DepartementFeaturePropertiesKeys.Nom]: string;
-	[DepartementFeaturePropertiesKeys.CodeRegion]: string;
-	[DepartementFeaturePropertiesKeys.PotentielSolaireTotal]: number;
-	[DepartementFeaturePropertiesKeys.PotentielSolaireLycees]: number;
-	[DepartementFeaturePropertiesKeys.PotentielSolaireColleges]: number;
-	[DepartementFeaturePropertiesKeys.PotentielSolairePrimaires]: number;
+	code_departement: string;
+	libelle_departement: string;
+	code_region: string;
+	potentiel_solaire_total: number;
+	potentiel_solaire_lycees: number;
+	potentiel_solaire_colleges: number;
+	potentiel_solaire_primaires: number;
 }
 export type DepartementFeature = DepartementsGeoJSON['features'][number];
 
@@ -80,3 +40,7 @@ export type DepartementsGeoJSON = GeoJSON.FeatureCollection<
 	GeoJSON.Polygon | GeoJSON.MultiPolygon,
 	DepartementFeatureProperties
 >;
+
+// Reference keys for proper access with maplibre layer properties
+export const DEPARTEMENT_GEOJSON_KEY_NOM: keyof DepartementFeatureProperties =
+	'libelle_departement';

--- a/application/app/models/etablissements.ts
+++ b/application/app/models/etablissements.ts
@@ -1,54 +1,26 @@
 import { NiveauPotentiel } from './common';
 
-/**
- * List of the Etablissement type properties.
- */
-//TODO: change values to camelCase after merge #190
-export const EtablissementPropertiesKeys = {
-	Id: 'identifiant_de_l_etablissement',
-	Nom: 'nom_etablissement',
-	Type: 'type_etablissement',
-	LibelleNature: 'libelle_nature',
-	CodeCommune: 'code_commune',
-	NomCommune: 'nom_commune',
-	CodeDepartement: 'code_departement',
-	LibelleDepartement: 'libelle_departement',
-	CodeRegion: 'code_region',
-	LibelleRegion: 'libelle_region',
-	SurfaceExploitableMax: 'surface_exploitable_max',
-	PotentielSolaire: 'potentiel_solaire',
-	PotentielNbFoyers: 'potentiel_nb_foyers',
-	Protection: 'protection',
-	Geometry: 'geom',
-	NbEleves: 'nb_eleves',
-	Adresse1: 'adresse_1',
-	Adresse2: 'adresse_2',
-	Adresse3: 'adresse_3',
-	CodePostal: 'code_postal',
-	NiveauPotentiel: 'niveau_potentiel',
-} as const;
-
 export type Etablissement = {
-	[EtablissementPropertiesKeys.Id]: string;
-	[EtablissementPropertiesKeys.Nom]: string;
-	[EtablissementPropertiesKeys.Type]: string;
-	[EtablissementPropertiesKeys.LibelleNature]: string;
-	[EtablissementPropertiesKeys.Adresse1]: string | null;
-	[EtablissementPropertiesKeys.Adresse2]: string | null;
-	[EtablissementPropertiesKeys.Adresse3]: string | null;
-	[EtablissementPropertiesKeys.CodePostal]: string;
-	[EtablissementPropertiesKeys.NbEleves]: number | null;
-	[EtablissementPropertiesKeys.CodeCommune]: string;
-	[EtablissementPropertiesKeys.NomCommune]: string;
-	[EtablissementPropertiesKeys.CodeDepartement]: string;
-	[EtablissementPropertiesKeys.LibelleDepartement]: string;
-	[EtablissementPropertiesKeys.CodeRegion]: string;
-	[EtablissementPropertiesKeys.LibelleRegion]: string;
-	[EtablissementPropertiesKeys.SurfaceExploitableMax]: number;
-	[EtablissementPropertiesKeys.PotentielSolaire]: number;
-	[EtablissementPropertiesKeys.PotentielNbFoyers]: number;
-	[EtablissementPropertiesKeys.Protection]: boolean;
-	[EtablissementPropertiesKeys.NiveauPotentiel]: NiveauPotentiel;
+	identifiant_de_l_etablissement: string;
+	nom_etablissement: string;
+	type_etablissement: string;
+	libelle_nature: string;
+	adresse_1: string | null;
+	adresse_2: string | null;
+	adresse_3: string | null;
+	code_postal: string;
+	nb_eleves: number | null;
+	code_commune: string;
+	nom_commune: string;
+	code_departement: string;
+	libelle_departement: string;
+	code_region: string;
+	libelle_region: string;
+	surface_exploitable_max: number;
+	potentiel_solaire: number;
+	potentiel_nb_foyers: number;
+	protection: boolean;
+	niveau_potentiel: NiveauPotentiel;
 };
 
 //TODO: remove later
@@ -65,30 +37,15 @@ export interface TopEtablissement {
 }
 
 // --- GeoJSON ----
-
-/**
- * List of the Etablissement Feature type properties.
- */
-export const EtablissementFeaturePropertiesKeys = {
-	Id: 'identifiant_de_l_etablissement',
-	Nom: 'nom_etablissement',
-	CodeCommune: 'code_commune',
-	CodeDepartement: 'code_departement',
-	CodeRegion: 'code_region',
-	PotentielSolaire: 'potentiel_solaire',
-	Protection: 'protection',
-	Geometry: 'geom',
-} as const;
-
 //TODO: clean unused properties
 export interface EtablissementFeatureProperties {
-	[EtablissementFeaturePropertiesKeys.Id]: string;
-	[EtablissementFeaturePropertiesKeys.Nom]: string;
-	[EtablissementFeaturePropertiesKeys.CodeCommune]: string;
-	[EtablissementFeaturePropertiesKeys.CodeDepartement]: string;
-	[EtablissementFeaturePropertiesKeys.CodeRegion]: string;
-	[EtablissementFeaturePropertiesKeys.PotentielSolaire]: number;
-	[EtablissementFeaturePropertiesKeys.Protection]: boolean;
+	identifiant_de_l_etablissement: string;
+	nom_etablissement: string;
+	code_commune: string;
+	code_departement: string;
+	code_region: string;
+	potentiel_solaire: number;
+	protection: boolean;
 }
 
 export type EtablissementsGeoJSON = GeoJSON.FeatureCollection<
@@ -97,3 +54,9 @@ export type EtablissementsGeoJSON = GeoJSON.FeatureCollection<
 >;
 
 export type EtablissementFeature = EtablissementsGeoJSON['features'][number];
+
+// Reference keys for proper access with maplibre layer properties
+export const ETABLISSEMENT_GEOJSON_KEY_PROTECTION: keyof EtablissementFeatureProperties =
+	'protection';
+export const ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE: keyof EtablissementFeatureProperties =
+	'potentiel_solaire';

--- a/application/app/models/regions.ts
+++ b/application/app/models/regions.ts
@@ -1,72 +1,39 @@
-import { NbEtablissementsByNiveauPotentiel, ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY } from './common';
+import { NbEtablissementsByNiveauPotentiel } from './common';
 import { TopEtablissement } from './etablissements';
 
-/**
- * List of the Region type properties.
- */
-//TODO: change values to camelCase after merge #190
-export const RegionPropertiesKeys = {
-	Id: 'code_region',
-	Nom: 'libelle_region',
-	SurfaceExploitableMaxTotal: 'surface_exploitable_max_total',
-	SurfaceExploitableMaxLycees: 'surface_exploitable_max_lycees',
-	NbElevesTotal: 'nb_eleves_total',
-	NbElevesLycees: 'nb_eleves_lycees',
-	NbEtablissementsTotal: 'nb_etablissements_total',
-	NbEtablissementsLycees: 'nb_etablissements_lycees',
-	NbEtablissementsProtegesTotal: 'nb_etablissements_proteges_total',
-	NbEtablissementsProtegesLycees: 'nb_etablissements_proteges_lycees',
-	PotentielSolaireTotal: 'potentiel_solaire_total',
-	PotentielSolaireLycees: 'potentiel_solaire_lycees',
-	PotentielNbFoyersTotal: 'potentiel_nb_foyers_total',
-	PotentielNbFoyersLycees: 'potentiel_nb_foyers_lycees',
-	TopEtablissementsTotal: 'top_etablissements_total',
-	TopEtablissementsLycees: 'top_etablissements_lycees',
-	NbEtablissementsParNiveauPotentielTotal: 'nb_etablissements_par_niveau_potentiel_total',
-	NbEtablissementsParNiveauPotentielLycees: 'nb_etablissements_par_niveau_potentiel_lycees',
-} as const;
-
 export type Region = {
-	[RegionPropertiesKeys.Id]: string;
-	[RegionPropertiesKeys.Nom]: string;
-	[RegionPropertiesKeys.SurfaceExploitableMaxLycees]: number;
-	[RegionPropertiesKeys.NbElevesTotal]: number;
-	[RegionPropertiesKeys.NbElevesLycees]: number;
-	[RegionPropertiesKeys.NbEtablissementsTotal]: number;
-	[RegionPropertiesKeys.NbEtablissementsLycees]: number;
-	[RegionPropertiesKeys.NbEtablissementsProtegesTotal]: number;
-	[RegionPropertiesKeys.NbEtablissementsProtegesLycees]: number;
-	[RegionPropertiesKeys.PotentielSolaireTotal]: number;
-	[RegionPropertiesKeys.PotentielSolaireLycees]: number;
-	[RegionPropertiesKeys.PotentielNbFoyersTotal]: number;
-	[RegionPropertiesKeys.PotentielNbFoyersLycees]: number;
-	[RegionPropertiesKeys.TopEtablissementsTotal]: Array<TopEtablissement>;
-	[RegionPropertiesKeys.TopEtablissementsLycees]: Array<TopEtablissement>;
-	[RegionPropertiesKeys.NbEtablissementsParNiveauPotentielTotal]: NbEtablissementsByNiveauPotentiel;
-	[RegionPropertiesKeys.NbEtablissementsParNiveauPotentielLycees]: NbEtablissementsByNiveauPotentiel;
+	code_region: string;
+	libelle_region: string;
+	surface_exploitable_max_total: number;
+	surface_exploitable_max_lycees: number;
+	nb_eleves_total: number;
+	nb_eleves_lycees: number;
+	nb_etablissements_total: number;
+	nb_etablissements_lycees: number;
+	nb_etablissements_proteges_total: number;
+	nb_etablissements_proteges_lycees: number;
+	potentiel_solaire_total: number;
+	potentiel_solaire_lycees: number;
+	potentiel_nb_foyers_total: number;
+	potentiel_nb_foyers_lycees: number;
+	top_etablissements_total: Array<TopEtablissement>;
+	top_etablissements_lycees: Array<TopEtablissement>;
+	nb_etablissements_par_niveau_potentiel_total: NbEtablissementsByNiveauPotentiel;
+	nb_etablissements_par_niveau_potentiel_lycees: NbEtablissementsByNiveauPotentiel;
 };
 
 // ---- GeoJSON ----
-/**
- * List of the Region Feature type properties.
- */
-export const RegionFeaturePropertiesKeys = {
-	Id: 'code_region',
-	Nom: 'libelle_region',
-	PotentielSolaireTotal: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.TOTAL,
-	PotentielSolaireLycees: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.LYCEES,
-	PotentielSolaireColleges: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.COLLEGES,
-	PotentielSolairePrimaires: ZONE_FEATURE_POTENTIEL_SOLAIRE_KEY.PRIMAIRES,
-} as const;
-
 export interface RegionFeatureProperties {
-	[RegionFeaturePropertiesKeys.Id]: string;
-	[RegionFeaturePropertiesKeys.Nom]: string;
-	[RegionFeaturePropertiesKeys.PotentielSolaireTotal]: number;
-	[RegionFeaturePropertiesKeys.PotentielSolaireLycees]: number;
-	[RegionFeaturePropertiesKeys.PotentielSolaireColleges]: number;
-	[RegionFeaturePropertiesKeys.PotentielSolairePrimaires]: number;
+	code_region: string;
+	libelle_region: string;
+	potentiel_solaire_total: number;
+	potentiel_solaire_lycees: number;
+	potentiel_solaire_colleges: number;
+	potentiel_solaire_primaires: number;
 }
 export type RegionFeature = RegionsGeoJSON['features'][number];
 
 export type RegionsGeoJSON = GeoJSON.FeatureCollection<GeoJSON.Polygon, RegionFeatureProperties>;
+
+// Reference keys for proper access with maplibre layer properties
+export const REGIONS_GEOJSON_KEY_NOM: keyof RegionFeatureProperties = 'libelle_region';

--- a/application/app/models/search.ts
+++ b/application/app/models/search.ts
@@ -1,48 +1,37 @@
-export const SearchPropertiesKeys = {
-	Id: 'id',
-	Libelle: 'libelle',
-	Source: 'source' as const,
-	ExtraData: 'extra_data',
-	ExtraDataNomCommune: 'nom_commune',
-	ExtraDataCodePostal: 'code_postal',
-	ExtraDataCodeRegion: 'code_region',
-	ExtraDataCodeDepartement: 'code_departement',
-	ExtraDataCodeCommune: 'code_commune',
-} as const;
-
 export type BaseResult = {
-	[SearchPropertiesKeys.Id]: string;
-	[SearchPropertiesKeys.Libelle]: string;
+	id: string;
+	libelle: string;
 };
 
 export type EtablissementResult = BaseResult & {
-	[SearchPropertiesKeys.Source]: 'etablissements';
-	[SearchPropertiesKeys.ExtraData]: {
-		[SearchPropertiesKeys.ExtraDataNomCommune]: string;
-		[SearchPropertiesKeys.ExtraDataCodePostal]: string;
-		[SearchPropertiesKeys.ExtraDataCodeRegion]: string;
-		[SearchPropertiesKeys.ExtraDataCodeDepartement]: string;
-		[SearchPropertiesKeys.ExtraDataCodeCommune]: string;
+	source: 'etablissements';
+	extra_data: {
+		nom_commune: string;
+		code_postal: string;
+		code_region: string;
+		code_departement: string;
+		code_commune: string;
 	};
 };
 
 export type CommuneResult = BaseResult & {
-	[SearchPropertiesKeys.Source]: 'communes';
-	[SearchPropertiesKeys.ExtraData]: {
-		[SearchPropertiesKeys.ExtraDataCodeRegion]: string;
-		[SearchPropertiesKeys.ExtraDataCodeDepartement]: string;
+	source: 'communes';
+	extra_data: {
+		code_region: string;
+		code_departement: string;
 	};
 };
 
 export type DepartementResult = BaseResult & {
-	[SearchPropertiesKeys.Source]: 'departements';
-	[SearchPropertiesKeys.ExtraData]: {
-		[SearchPropertiesKeys.ExtraDataCodeRegion]: string;
+	source: 'departements';
+	extra_data: {
+		code_region: string;
 	};
 };
 
 export type RegionResult = BaseResult & {
-	[SearchPropertiesKeys.Source]: 'regions';
+	source: 'regions';
+	extra_data: null;
 };
 
 export type SearchResult = EtablissementResult | CommuneResult | DepartementResult | RegionResult;


### PR DESCRIPTION
### Description
Github issue : N/A

Cette PR a pour objectif de supprimer l'utilisation de constante dans les modèles utilisés. 
On garde le mapping qui permet de faire correspondre une colonne des tables en base de données vers le nom d'une propriété d'un modèle. 
L'utilisation de constante était de trop et posait des problèmes d'auto-complétion.

### Comment tester ?
`npm run build`

### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [x] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)