### PR TITLE
[FRONT] refactor: improve search query by splitting query and match every part

### DIFF
--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -2,7 +2,7 @@
 
 # Generate database and export geojson
 # ARG GENERATOR_IMAGE=13_potentiel_solaire_mock_data
-ARG GENERATOR_IMAGE=ghcr.io/dataforgoodfr/13_potentiel_solaire_db:0.1.0.20250420
+ARG GENERATOR_IMAGE=ghcr.io/dataforgoodfr/13_potentiel_solaire_db:0.1.0.20250629
 FROM ${GENERATOR_IMAGE} AS generator
 
 FROM node:18-slim AS base

--- a/application/README.md
+++ b/application/README.md
@@ -119,7 +119,7 @@ Visual studio code est recommandé pour le développement de l'application.
 
 ```sh
 # lancer la commande depuis le répertoire application
-docker create --name 13_potentiel_solaire_data_tmp ghcr.io/dataforgoodfr/13_potentiel_solaire_db:0.1.0.20250420 /bin/true && \
+docker create --name 13_potentiel_solaire_data_tmp ghcr.io/dataforgoodfr/13_potentiel_solaire_db:0.1.0.20250629 /bin/true && \
 docker cp 13_potentiel_solaire_data_tmp:/app/output/db/data.duckdb ./database && \
 docker cp 13_potentiel_solaire_data_tmp:/app/output/geojson/. ./public/data && \
 docker rm -f 13_potentiel_solaire_data_tmp


### PR DESCRIPTION
### Description
Github issue : #206

Cette PR a pour objectif d'améliorer le moteur de recherche qui ne permet pas de rajouter des élements comme le code postal ou le nom d'une commune dans une recherche d'établissement. 
Aujourd'hui la recherche doit exactement matcher l'ordre des éléments du libellé en base, cette recherche simple sera également améliorée puisque chaque mot de la requête sera matché avec les libellés en base.
De plus, les zones (régions, départements, communes) seront remontés en premier dans les résultats pour les trouver plus facilement.

### Comment tester ?
- Effectuer une recherche sur un établissement au nom commun (ex: "jean jaurès") en ajoutant un nom de ville dans la requête ou un code postal => on devrait pouvoir retrouver facilement un établissement
- Effecture une recherche sur une région, un département ou une commune, elle doit arriver en premier avant les établissements.

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
