### PR TITLE
[DATA] Enhance search view

### DIFF
--- a/algorithme/database/versions/2025_06_28_1209_enhance_search_view.py
+++ b/algorithme/database/versions/2025_06_28_1209_enhance_search_view.py
@@ -1,0 +1,69 @@
+"""enhance search view
+
+Revision ID: 5153ebff0158
+Revises: 5f96d921513d
+Create Date: 2025-06-28 12:09:06.199271
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5153ebff0158'
+down_revision: Union[str, None] = '5f96d921513d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# schema
+etablissements_table = "etablissements"
+communes_table = "communes"
+departements_table = "departements"
+regions_table = "regions"
+search_view_table = "search_view"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute(f"""
+    UPDATE {search_view_table} sv
+    SET 
+        extra_data = to_json(struct_pack(c.code_departement, c.libelle_departement))
+    FROM communes c
+    WHERE sv.source_table = 'communes'
+    AND sv.id = c.code_commune
+    """)
+
+    op.execute(f"""
+    UPDATE {search_view_table} sv
+    SET 
+        sanitized_libelle = lower(regexp_replace(regexp_replace(strip_accents(e.nom_etablissement), '[^\w\s]', ' ', 'g'), '[\s]{2,}', ' ', 'g')) 
+            || ' ' || e.code_postal
+            || ' ' || lower(regexp_replace(regexp_replace(strip_accents(e.nom_commune), '[^\w\s]', ' ', 'g'), '[\s]{2,}', ' ', 'g')) 
+    FROM etablissements e
+    WHERE sv.source_table = 'etablissements'
+    AND sv.id = e.identifiant_de_l_etablissement;
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    # Previous search view table
+    op.execute(f"""
+    UPDATE {search_view_table} sv
+    SET 
+         extra_data = NULL::json
+    WHERE sv.source_table = 'communes'
+    """)
+
+    op.execute(f"""
+    UPDATE {search_view_table} sv
+    SET 
+        sanitized_libelle = lower(regexp_replace(regexp_replace(strip_accents(e.nom_etablissement), '[^\w\s]', ' ', 'g'), '[\s]{2,}', ' ', 'g'))
+    FROM etablissements e
+    WHERE sv.source_table = 'etablissements'
+    AND sv.id = e.identifiant_de_l_etablissement;
+    """)


### PR DESCRIPTION
### Description
Github issues : 
- https://github.com/dataforgoodfr/13_potentiel_solaire/issues/217
- https://github.com/dataforgoodfr/13_potentiel_solaire/issues/206

Cette PR a pour objectif d'améliorer le moteur de recherche en modifiant la table `search_view` qui utilisée par celui-ci.

Une fois merge je pusherai un nouveau tag de `potentiel_solaire_db`.

### Comment tester ?
Upgrade database : `alembic upgrade head`

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'agorithme
- Je respecte au mieux la [PEP8](https://peps.python.org/pep-0008/) notamment sur la façon de nommer les classes, fonctions et variables
- Les arguments des fonctions sont typés
- Chaque nouvelle fonction a une docstring
- Je mets à jour les docstrings des fonctions que j'ai modifiée
- J'ai ajouté des commentaires dans le code qui expliquent **pourquoi** certaines opérations sont faites
- Les noms des fonctions & variables aident à la lecture et compréhension du code
- J'évite des fonctions qui prennent en argument des dataframes et renvoient celles-ci modifiées
- J'écrit des tests unitaires pour les fonctions les plus complexes
- Je consulte cette [page](../docs/algorithme_best_code_practices.md) si je veux avoir plus d'explications et d'exemples sur ces bonnes pratiques

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
