### PR TITLE
fix: direct db access instead of fetch in api route redirect

### DIFF
--- a/application/app/etablissements/[id]/route.tsx
+++ b/application/app/etablissements/[id]/route.tsx
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { fetchEtablissement } from '@/app/utils/fetchers/fetchEtablissement';
+import { fetchEtablissementById } from '@/app/lib/data';
 import { buildActiveTabParam, buildCodesParam } from '@/app/utils/state-utils';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
 	const { id } = await params;
 
 	try {
-		// In Next.js, this code runs on the Edge Runtime, which does not have access to the app's internal API routes via relative URLs, we have to pass the origin
-		const etablissement = await fetchEtablissement(id, request.nextUrl.origin);
+		const etablissement = await fetchEtablissementById(id);
 		if (etablissement) {
 			const { code_region, code_departement, code_commune } = etablissement;
 			const codesParams = buildCodesParam({

--- a/application/app/utils/fetchers/fetchEtablissement.ts
+++ b/application/app/utils/fetchers/fetchEtablissement.ts
@@ -2,9 +2,9 @@ import { Etablissement } from '@/app/models/etablissements';
 
 const API_ROUTE = '/api/etablissements';
 
-export async function fetchEtablissement(id: string, origin?: string) {
+export async function fetchEtablissement(id: string) {
 	try {
-		const url = origin ? `${origin}${API_ROUTE}/${id}` : `${API_ROUTE}/${id}`;
+		const url = `${API_ROUTE}/${id}`;
 
 		const res = await fetch(url);
 		if (!res.ok) throw new Error('Failed to load etablissement from API');


### PR DESCRIPTION
### Description
Github issue : #255 

Cette PR a pour objectif de corriger le lien d'etablissement depuis le top 3.
Actuellement en version déployé, l'appel au fetch ne fonctionne pas.
Cela est du à l'environnement de déploiement.
- Le middleware a été retiré car non adapté pour faire des requêtes "longues" - [voir doc NextJS](https://nextjs.org/docs/app/getting-started/route-handlers-and-middleware#middleware)
- L'api route est côté serveur et peut accéder directement à la base de données sans appel externe. Ces appels d'API qui ne sont pas possibles sans ajouter de variable d'environnement (qui a été retiré récemment). Comme c'est côté serveur, l'`origin` de la request correspondait au serveur interne au docker.
- Pour le middleware c'est le meme probleme concernant l'url, il aurait fallu utiliser une variable d'environnement
=> L'utilisation d'une variable complexifie le déploiement sur la swarm donc on l'ecarte pour le moment.

J'ai testé en déployant sur une vm, la redirection fonctionne mais la page se recharge puisque c'est une route (une page) a part entiere. 

### Comment tester ?
Il faudra tester en déployant une nouvelle version sur le swarm data for good.

### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [ ] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

Related to #254 