### PR TITLE
[FRONT ] Evolutions UI

### DIFF
--- a/application/app/components/Footer.tsx
+++ b/application/app/components/Footer.tsx
@@ -152,9 +152,7 @@ export default function Footer() {
 			{/* Close view */}
 			{!isOpen && (
 				<div className='flex items-center justify-center gap-4 bg-blue py-2'>
-					<Image src={partners[0].logo} alt='Logo Greenpeace' width={35} height={35} />
-					<span className='text-sm font-semibold italic text-white'>ft.</span>
-					<Image src={partners[1].logo} alt='Logo Data For Good' width={35} height={35} />
+					<h2 className='text-base font-bold'>{footerDescription.title}</h2>
 				</div>
 			)}
 		</footer>

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -7,6 +7,7 @@ import {
 	LngLatLike,
 	Map as MapFromReactMapLibre,
 	MapMouseEvent,
+	MapProps as MapPropsReactMapLibre,
 	MapRef,
 	Source,
 } from 'react-map-gl/maplibre';
@@ -75,13 +76,13 @@ const MOBILE_VIEW_STATE = {
 	longitude: 2.388334,
 	latitude: 43.903354,
 	zoom: 4.1,
-};
+} satisfies MapPropsReactMapLibre['initialViewState'];
 
 const DESKTOP_VIEW_STATE = {
 	longitude: 2.388334,
 	latitude: 44.803354,
 	zoom: 4.5,
-};
+} satisfies MapPropsReactMapLibre['initialViewState'];
 
 const ANIMATION_TIME_MS = 800;
 

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -117,7 +117,6 @@ function interact(enabled: boolean) {
 		scrollZoom: enabled,
 		boxZoom: enabled,
 		dragRotate: enabled,
-		dragPan: enabled,
 		keyboard: enabled,
 		doubleClickZoom: enabled,
 		touchZoomRotate: enabled,

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -7,7 +7,6 @@ import {
 	LngLatLike,
 	Map as MapFromReactMapLibre,
 	MapMouseEvent,
-	MapProps as MapPropsReactMapLibre,
 	MapRef,
 	Source,
 } from 'react-map-gl/maplibre';
@@ -72,11 +71,17 @@ const MAP_STYLE_URL = `/map-styles/map-style.json`;
 // - Indiquer la date de mise à jour du fichier map-style.json
 // - Vérifier et respecter la licence (Licence Ouverte 2.0 ou ODbL)
 
-const initialViewState = {
-	longitude: 1.888334,
-	latitude: 45.603354,
-	zoom: 4,
-} satisfies MapPropsReactMapLibre['initialViewState'];
+const MOBILE_VIEW_STATE = {
+	longitude: 2.388334,
+	latitude: 43.903354,
+	zoom: 4.1,
+};
+
+const DESKTOP_VIEW_STATE = {
+	longitude: 2.388334,
+	latitude: 44.803354,
+	zoom: 4.5,
+};
 
 const ANIMATION_TIME_MS = 800;
 
@@ -210,9 +215,12 @@ export default function FranceMap() {
 	}
 
 	const easeToInitialView = useCallback(() => {
+		const isDesktop = window.innerWidth >= 768;
+		const view = isDesktop ? DESKTOP_VIEW_STATE : MOBILE_VIEW_STATE;
+
 		easeTo({
-			center: [initialViewState.longitude, initialViewState.latitude],
-			zoom: initialViewState.zoom,
+			center: [view.longitude, view.latitude],
+			zoom: view.zoom,
 		});
 	}, []);
 
@@ -395,7 +403,7 @@ export default function FranceMap() {
 		<div className='relative flex h-full w-full flex-col'>
 			<MapFromReactMapLibre
 				ref={mapRef}
-				initialViewState={initialViewState}
+				initialViewState={MOBILE_VIEW_STATE}
 				mapStyle={MAP_STYLE_URL}
 				interactiveLayerIds={[
 					regionsLayer.id,
@@ -410,6 +418,14 @@ export default function FranceMap() {
 				onLoad={() => {
 					setIsLoaded(true);
 					toggleInteractions(false);
+					if (mapRef.current) {
+						const isDesktop = window.innerWidth >= 768;
+						const view = isDesktop ? DESKTOP_VIEW_STATE : MOBILE_VIEW_STATE;
+						mapRef.current.jumpTo({
+							center: [view.longitude, view.latitude],
+							zoom: view.zoom,
+						});
+					}
 				}}
 				{...interact(isInteractive)}
 			>
@@ -517,12 +533,12 @@ export default function FranceMap() {
 						)}
 					</Source>
 				)}
+				<div className='absolute inset-x-0 bottom-24 z-30 flex flex-col items-start justify-center px-4 md:flex-row md:items-center md:justify-center md:gap-4'>
+					<Legend thresholds={COLOR_THRESHOLDS[level]} />
+					<MenuDrom />
+				</div>
 			</MapFromReactMapLibre>
 			{level !== 'nation' && <BackButton onBack={goBackOneLevel} />}
-			<div className='z-30 !mb-24 flex flex-col items-start justify-center gap-4 px-4 md:mb-6 md:flex-row md:items-center md:justify-center'>
-				<Legend thresholds={COLOR_THRESHOLDS[level]} />
-				<MenuDrom />
-			</div>
 			{isLoading && (
 				<div className='absolute left-0 top-0 h-[100%] w-[100%] bg-slate-400 opacity-50'>
 					<Loading />

--- a/application/app/components/Map/Legend/Legend.tsx
+++ b/application/app/components/Map/Legend/Legend.tsx
@@ -25,7 +25,7 @@ export default function Legend({ thresholds }: Legend) {
 	const lastThresholdUnit = getClosestEnergyUnit(lastThreshold);
 
 	return (
-		<div className='pointer-events-none flex flex-grow-0 flex-col items-center rounded-md bg-blue p-2 text-sm text-white'>
+		<div className='pointer-events-none flex flex-grow-0 flex-col items-center rounded-md bg-blue p-1 text-xs text-white md:text-sm'>
 			{getLabel(lastThresholdUnit)}
 			<LegendColorScale thresholds={thresholds} unit={lastThresholdUnit} />
 		</div>

--- a/application/app/components/NavBar.tsx
+++ b/application/app/components/NavBar.tsx
@@ -5,6 +5,7 @@ import { KeyboardEvent, Suspense, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { ListFilter, Menu, X } from 'lucide-react';
 
 import GOOD from '../../public/images/GOOD.svg';
@@ -71,10 +72,30 @@ export default function NavBar() {
 					<div className='m-4 flex w-full items-center gap-2 xl:min-w-0 xl:max-w-[600px] xl:flex-grow'>
 						<Suspense>
 							<SearchBar />
-							<ListFilter
-								className='shrink-0 cursor-pointer stroke-green'
-								size={24}
-							/>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger asChild>
+										<button
+											className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+											disabled
+										>
+											<ListFilter
+												className='shrink-0 cursor-pointer stroke-green'
+												size={24}
+											/>
+										</button>
+									</Tooltip.Trigger>
+									<Tooltip.Portal>
+										<Tooltip.Content
+											className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+											sideOffset={5}
+										>
+											Cette fonctionnalité n&apos;est pas encore disponible !
+											<Tooltip.Arrow className='fill-black' />
+										</Tooltip.Content>
+									</Tooltip.Portal>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Suspense>
 					</div>
 				)}
@@ -120,7 +141,7 @@ export default function NavBar() {
 					</div>
 
 					{/* Liens verticaux */}
-					<div className='relative w-full space-y-4 bg-green px-6 pb-20 pt-4 text-base font-bold text-darkgreen overflow-hidden '>
+					<div className='relative w-full space-y-4 overflow-hidden bg-green px-6 pb-20 pt-4 text-base font-bold text-darkgreen'>
 						{links.map((link) => (
 							<Link
 								key={link.href}

--- a/application/app/components/content/actions.ts
+++ b/application/app/components/content/actions.ts
@@ -1,14 +1,14 @@
 export const ACTION_LINKS = {
-  petition: {
-    label: 'Signez la pétition nationale',
-    url: 'https://www.greenpeace.fr/ecole-mal-isolee-eleves-en-difficulte/',
-  },
-  contact: {
-    label: 'Nous contacter',
-    url: 'mailto:contact@greenpeace.fr', // TODO : placer le correct email
-  },
-  commentAgir: {
-    label: 'Comment agir ?',
-    url: '/comment-agir',
-  },
+	petition: {
+		label: 'Signez la pétition nationale',
+		url: 'https://www.greenpeace.fr/ecole-mal-isolee-eleves-en-difficulte/',
+	},
+	contact: {
+		label: 'Nous contacter',
+		url: 'mailto:contact@greenpeace.fr', // TODO : placer le correct email
+	},
+	commentAgir: {
+		label: 'Comment agir ?',
+		url: '/comment-agir',
+	},
 };

--- a/application/app/components/fiches/ficheEtablissement/InstallationCard.tsx
+++ b/application/app/components/fiches/ficheEtablissement/InstallationCard.tsx
@@ -23,7 +23,7 @@ const InstallationCard = ({ surfaceExploitableMax }: installationCardProps) => {
 				</span>{' '}
 				{hasSurface && 'M²'}
 			</p>
-			<br />
+			{/* <br /> */}
 			{/* Partie Graphique non implémentée pour l'instant */}
 			{/* <div className='flex gap-1 text-sm text-grey'>
 				<ChartPie />

--- a/application/app/components/fiches/ficheEtablissement/InstallationCard.tsx
+++ b/application/app/components/fiches/ficheEtablissement/InstallationCard.tsx
@@ -24,7 +24,7 @@ const InstallationCard = ({ surfaceExploitableMax }: installationCardProps) => {
 				{hasSurface && 'M²'}
 			</p>
 			<br />
-      {/* Partie Graphique non implémentée pour l'instant */}
+			{/* Partie Graphique non implémentée pour l'instant */}
 			{/* <div className='flex gap-1 text-sm text-grey'>
 				<ChartPie />
 				<p className='font-bold'>

--- a/application/app/components/fiches/ficheEtablissement/InstallationCard.tsx
+++ b/application/app/components/fiches/ficheEtablissement/InstallationCard.tsx
@@ -1,4 +1,4 @@
-import { ChartPie, Ruler } from 'lucide-react';
+import { Ruler } from 'lucide-react';
 
 const UNKNOWN_TEXTS = {
 	surfaceExploitableMax: 'Non disponible',
@@ -24,12 +24,13 @@ const InstallationCard = ({ surfaceExploitableMax }: installationCardProps) => {
 				{hasSurface && 'M²'}
 			</p>
 			<br />
-			<div className='flex gap-1 text-sm text-grey'>
+      {/* Partie Graphique non implémentée pour l'instant */}
+			{/* <div className='flex gap-1 text-sm text-grey'>
 				<ChartPie />
 				<p className='font-bold'>
 					Estimation des revenus mensuels maximaux de l&apos;installation
 				</p>
-			</div>
+			</div> */}
 		</div>
 	);
 };

--- a/application/app/components/fiches/ficheEtablissement/IntepretationMessage.tsx
+++ b/application/app/components/fiches/ficheEtablissement/IntepretationMessage.tsx
@@ -43,7 +43,7 @@ const InterpretationMessage = ({ niveau_potentiel }: InterpretationMessageProps)
 						alt={`Potentiel ${ALT_LABELS[niveau_potentiel]}`}
 						width={143}
 						height={130}
-						className='animate-slide-in absolute -bottom-16 -left-8 motion-reduce:animate-none'
+						className='absolute -bottom-16 -left-8 animate-slide-in motion-reduce:animate-none'
 					/>
 				</div>
 

--- a/application/app/components/fiches/ficheEtablissement/ficheEtablissement.tsx
+++ b/application/app/components/fiches/ficheEtablissement/ficheEtablissement.tsx
@@ -4,7 +4,7 @@ import AccordionCard from '../shared/AccordionCard';
 import ActionButtons from '../shared/ActionButtons';
 import PotentielSolaireCard from '../shared/PotentielSolaireCard';
 import EtablissementCard from './EtablissementCard';
-import GraphiqueCard from './GraphiqueCard';
+// import GraphiqueCard from './GraphiqueCard';
 import InstallationCard from './InstallationCard';
 import InterpretationMessage from './IntepretationMessage';
 import ProtectionCard from './ProtectionCard';
@@ -31,7 +31,7 @@ export default function FicheEtablissement({ etablissement }: FicheEtablissement
 			<hr className='my-4' />
 			<div className='ml-2'>
 				<InstallationCard surfaceExploitableMax={etablissement.surface_exploitable_max} />
-				<GraphiqueCard />
+				{/* <GraphiqueCard /> */}
 			</div>
 			<hr className='my-4' />
 			<AccordionCard />

--- a/application/app/components/fiches/shared/ActionButtons.tsx
+++ b/application/app/components/fiches/shared/ActionButtons.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { toast } from '@/hooks/use-toast';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { Download, Share2 } from 'lucide-react';
 
 const ActionButtons = () => {
@@ -54,9 +55,27 @@ const ActionButtons = () => {
 			>
 				<Share2 className='h-5 w-5' />
 			</button>
-			<button className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'>
-				<Download />
-			</button>
+			<Tooltip.Provider>
+				<Tooltip.Root>
+					<Tooltip.Trigger asChild>
+						<button
+							className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+							disabled
+						>
+							<Download />
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Portal>
+						<Tooltip.Content
+							className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+							sideOffset={5}
+						>
+							Cette fonctionnalité n&apos;est pas encore disponible !
+							<Tooltip.Arrow className='fill-black' />
+						</Tooltip.Content>
+					</Tooltip.Portal>
+				</Tooltip.Root>
+			</Tooltip.Provider>
 		</div>
 	);
 };

--- a/application/app/components/fiches/shared/PotentielSolaireCard.tsx
+++ b/application/app/components/fiches/shared/PotentielSolaireCard.tsx
@@ -1,6 +1,7 @@
 import { JSX } from 'react';
 
 import { getColorForPotentiel } from '@/app/utils/solar-utils';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { CircleHelp, HousePlug, Users, Zap } from 'lucide-react';
 
 import { getClosestEnergyUnit, getFormattedPotentielSolaire } from '../../../utils/energy-utils';
@@ -88,7 +89,27 @@ export default function PotentielSolaireCard({
 						<span className='font-bold'>2 personnes</span>
 					</div>
 				</div>
-				<CircleHelp />
+				<Tooltip.Provider>
+					<Tooltip.Root>
+						<Tooltip.Trigger asChild>
+							<button
+								className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+								disabled
+							>
+								<CircleHelp />
+							</button>
+						</Tooltip.Trigger>
+						<Tooltip.Portal>
+							<Tooltip.Content
+								className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+								sideOffset={5}
+							>
+								5000kwh/an pour un foyer de 2 personnes
+								<Tooltip.Arrow className='fill-black' />
+							</Tooltip.Content>
+						</Tooltip.Portal>
+					</Tooltip.Root>
+				</Tooltip.Provider>
 			</div>
 		</div>
 	);

--- a/application/app/components/fiches/shared/TopCard.tsx
+++ b/application/app/components/fiches/shared/TopCard.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
-
+// import Link from 'next/link';
 import { TopEtablissement } from '@/app/models/etablissements';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { Sun } from 'lucide-react';
 
 const UNKNOWN_TEXTS = {
@@ -28,12 +28,33 @@ const TopCard = ({ topEtablissements }: Props) => {
 				{topEtablissements.slice(0, 3).map((etab, index) => (
 					<li key={etab.id}>
 						{medals[index]}{' '}
-						<Link
-							href={`/etablissements/${etab.id}`}
-							className='underline decoration-dotted decoration-2 underline-offset-4 transition hover:text-primary'
-						>
-							{etab.libelle}
-						</Link>
+						<Tooltip.Provider>
+							<Tooltip.Root>
+								<Tooltip.Trigger asChild>
+									<button
+										className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+										disabled
+									>
+										<span
+											// href={`/etablissements/${etab.id}`}
+											aria-disabled='true'
+											className='underline decoration-dotted decoration-2 underline-offset-4 transition hover:text-primary'
+										>
+											{etab.libelle}
+										</span>
+									</button>
+								</Tooltip.Trigger>
+								<Tooltip.Portal>
+									<Tooltip.Content
+										className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+										sideOffset={5}
+									>
+										Cette fonctionnalité n&apos;est pas encore disponible !
+										<Tooltip.Arrow className='fill-black' />
+									</Tooltip.Content>
+								</Tooltip.Portal>
+							</Tooltip.Root>
+						</Tooltip.Provider>
 					</li>
 				))}
 			</ul>

--- a/application/app/components/fiches/shared/TopCard.tsx
+++ b/application/app/components/fiches/shared/TopCard.tsx
@@ -31,9 +31,9 @@ const TopCard = ({ topEtablissements }: Props) => {
 						<Tooltip.Provider>
 							<Tooltip.Root>
 								<Tooltip.Trigger asChild>
-									<button
-										className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
-										disabled
+									<span
+										className='hover:bg-gray-100 rounded text-darkgreen transition'
+										aria-disabled='true'
 									>
 										<span
 											// href={`/etablissements/${etab.id}`}
@@ -42,7 +42,7 @@ const TopCard = ({ topEtablissements }: Props) => {
 										>
 											{etab.libelle}
 										</span>
-									</button>
+									</span>
 								</Tooltip.Trigger>
 								<Tooltip.Portal>
 									<Tooltip.Content

--- a/application/app/not-found.tsx
+++ b/application/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+	return (
+		<div className='mt-8 p-8 text-center text-white'>
+			<h2 className='mb-8 text-2xl font-bold'>404 – Page introuvable</h2>
+			<p>La page que vous cherchez n&apos;existe pas.</p>
+		</div>
+	);
+}


### PR DESCRIPTION
### Description
Github issue : _[#250](https://github.com/dataforgoodfr/13_potentiel_solaire/issues/250)_

Cette PR a pour objectif de corriger plusieurs points UI:
- Bouton filtre -> Désactiver le bouton et mettre une tooltip "Cette fonctionnalité n'est pas encore disponible !"
<img width="966" height="611" alt="Capture d’écran 2025-07-13 à 17 57 11" src="https://github.com/user-attachments/assets/8b32a0b2-d9cf-4855-9775-fe72b4ff19dc" />

- Supprimer la partie placeholder contenant les "Graphiques" car ce n'est pas implémenté. Les boutons call to action devraient alors remonter plus haut et etre visible sans avoir a scroller (notamment en vue desktop).
<img width="966" height="611" alt="Capture d’écran 2025-07-13 à 17 57 44" src="https://github.com/user-attachments/assets/8ed7330c-f8ea-47eb-887c-a0607c93123d" />

- Désactiver le bouton de téléchargement et mettre une tooltip "Cette fonctionnalité n'est pas encore disponible !"
<img width="966" height="611" alt="Capture d’écran 2025-07-13 à 17 57 28" src="https://github.com/user-attachments/assets/05b50724-8117-48e9-91f1-f0d092f2b1ac" />

- Implémenter la tooltip de la section équivalent conso foyers, y indiquer "5000kwh/an pour un foyer de 2 personnes" 
<img width="966" height="611" alt="Capture d’écran 2025-07-13 à 18 05 22" src="https://github.com/user-attachments/assets/64cec786-af65-4987-9c72-9d637afaac10" />

- Liens Top 3, pour le moment -> Désactiver le lien et mettre une tooltip "Cette fonctionnalité n'est pas encore disponible !"
<img width="966" height="611" alt="Capture d’écran 2025-07-13 à 18 05 12" src="https://github.com/user-attachments/assets/d5d8968c-f74a-4874-b853-250302deae90" />

-En vue mobile, il n'est pas nécessaire d'afficher les logos des assos, c'est plutôt "Notre objectif" qui est visible, la flèche suffirait également
<img width="347" height="614" alt="Capture d’écran 2025-07-13 à 18 12 25" src="https://github.com/user-attachments/assets/ceea21f9-0b74-4be4-b787-a2c0be5030b1" />

- Corriger le contraste du texte sur une page inconnue + mettre un texte en français à la place de "This page could not be found"
<img width="966" height="611" alt="Capture d’écran 2025-07-13 à 17 56 23" src="https://github.com/user-attachments/assets/6bf39a0d-0ece-42a3-a5e1-dd6a0d454ab7" />

- Sur la carte, améliorer la vue mobile et le zoom sur la vue desktop
<img width="739" height="614" alt="Capture d’écran 2025-07-13 à 19 01 13" src="https://github.com/user-attachments/assets/62136de4-d806-4dcb-906d-3f0e68ad702a" />
<img width="346" height="614" alt="Capture d’écran 2025-07-13 à 19 01 30" src="https://github.com/user-attachments/assets/dc0337f4-ce3e-42a6-9771-58b8b224568b" />


### Pour faciliter la validation de ma PR
- [X] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [X] Les pre-commit passent
- [X] Les test unitaires passent
- [X] Le code modifié fonctionne en local
- [X] J'ai demandé une peer-review à un autre bénévole du projet

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
