### PR TITLE
chore: fix tooltip into popover

### DIFF
--- a/application/app/components/NavBar.tsx
+++ b/application/app/components/NavBar.tsx
@@ -5,7 +5,7 @@ import { KeyboardEvent, Suspense, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import * as Tooltip from '@radix-ui/react-tooltip';
+import * as Popover from '@radix-ui/react-popover';
 import { ListFilter, Menu, X } from 'lucide-react';
 
 import GOOD from '../../public/images/GOOD.svg';
@@ -72,30 +72,28 @@ export default function NavBar() {
 					<div className='m-4 flex w-full items-center gap-2 xl:min-w-0 xl:max-w-[600px] xl:flex-grow'>
 						<Suspense>
 							<SearchBar />
-							<Tooltip.Provider>
-								<Tooltip.Root>
-									<Tooltip.Trigger asChild>
-										<button
-											className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
-											disabled
-										>
-											<ListFilter
-												className='shrink-0 cursor-pointer stroke-green'
-												size={24}
-											/>
-										</button>
-									</Tooltip.Trigger>
-									<Tooltip.Portal>
-										<Tooltip.Content
-											className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
-											sideOffset={5}
-										>
-											Cette fonctionnalité n&apos;est pas encore disponible !
-											<Tooltip.Arrow className='fill-black' />
-										</Tooltip.Content>
-									</Tooltip.Portal>
-								</Tooltip.Root>
-							</Tooltip.Provider>
+							<Popover.Root>
+								<Popover.Trigger asChild>
+									<button
+										aria-disabled='true'
+										className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+									>
+										<ListFilter
+											className='shrink-0 cursor-pointer stroke-green'
+											size={24}
+										/>
+									</button>
+								</Popover.Trigger>
+								<Popover.Portal>
+									<Popover.Content
+										className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+										sideOffset={5}
+									>
+										Cette fonctionnalité n&apos;est pas encore disponible !
+										<Popover.Arrow className='fill-black' />
+									</Popover.Content>
+								</Popover.Portal>
+							</Popover.Root>
 						</Suspense>
 					</div>
 				)}
@@ -116,7 +114,7 @@ export default function NavBar() {
 
 			{/* Menu mobile plein écran */}
 			{isOpen && (
-				<div className='fixed inset-0 z-50 flex flex-col bg-blue'>
+				<div className='fixed inset-0 z-[9999] flex flex-col bg-blue'>
 					{/* Bouton de fermeture */}
 					<div className='flex items-start justify-between p-4'>
 						<button

--- a/application/app/components/fiches/shared/ActionButtons.tsx
+++ b/application/app/components/fiches/shared/ActionButtons.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { toast } from '@/hooks/use-toast';
-import * as Tooltip from '@radix-ui/react-tooltip';
+import * as Popover from '@radix-ui/react-popover';
 import { Download, Share2 } from 'lucide-react';
 
 const ActionButtons = () => {
@@ -55,27 +55,25 @@ const ActionButtons = () => {
 			>
 				<Share2 className='h-5 w-5' />
 			</button>
-			<Tooltip.Provider>
-				<Tooltip.Root>
-					<Tooltip.Trigger asChild>
-						<button
-							className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
-							disabled
-						>
-							<Download />
-						</button>
-					</Tooltip.Trigger>
-					<Tooltip.Portal>
-						<Tooltip.Content
-							className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
-							sideOffset={5}
-						>
-							Cette fonctionnalité n&apos;est pas encore disponible !
-							<Tooltip.Arrow className='fill-black' />
-						</Tooltip.Content>
-					</Tooltip.Portal>
-				</Tooltip.Root>
-			</Tooltip.Provider>
+			<Popover.Root>
+				<Popover.Trigger asChild>
+					<button
+						aria-disabled='true'
+						className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+					>
+						<Download />
+					</button>
+				</Popover.Trigger>
+				<Popover.Portal>
+					<Popover.Content
+						className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+						sideOffset={5}
+					>
+						Cette fonctionnalité n&apos;est pas encore disponible !
+						<Popover.Arrow className='fill-black' />
+					</Popover.Content>
+				</Popover.Portal>
+			</Popover.Root>
 		</div>
 	);
 };

--- a/application/app/components/fiches/shared/PotentielSolaireCard.tsx
+++ b/application/app/components/fiches/shared/PotentielSolaireCard.tsx
@@ -1,7 +1,7 @@
 import { JSX } from 'react';
 
 import { getColorForPotentiel } from '@/app/utils/solar-utils';
-import * as Tooltip from '@radix-ui/react-tooltip';
+import * as Popover from '@radix-ui/react-popover';
 import { CircleHelp, HousePlug, Users, Zap } from 'lucide-react';
 
 import { getClosestEnergyUnit, getFormattedPotentielSolaire } from '../../../utils/energy-utils';
@@ -89,27 +89,25 @@ export default function PotentielSolaireCard({
 						<span className='font-bold'>2 personnes</span>
 					</div>
 				</div>
-				<Tooltip.Provider>
-					<Tooltip.Root>
-						<Tooltip.Trigger asChild>
-							<button
-								className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
-								disabled
-							>
-								<CircleHelp />
-							</button>
-						</Tooltip.Trigger>
-						<Tooltip.Portal>
-							<Tooltip.Content
-								className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
-								sideOffset={5}
-							>
-								5000kwh/an pour un foyer de 2 personnes
-								<Tooltip.Arrow className='fill-black' />
-							</Tooltip.Content>
-						</Tooltip.Portal>
-					</Tooltip.Root>
-				</Tooltip.Provider>
+				<Popover.Root>
+					<Popover.Trigger asChild>
+						<button
+							aria-disabled='true'
+							className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+						>
+							<CircleHelp />
+						</button>
+					</Popover.Trigger>
+					<Popover.Portal>
+						<Popover.Content
+							className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+							sideOffset={5}
+						>
+							5000 kWh/an pour un foyer de 2 personnes
+							<Popover.Arrow className='fill-black' />
+						</Popover.Content>
+					</Popover.Portal>
+				</Popover.Root>
 			</div>
 		</div>
 	);

--- a/application/app/components/fiches/shared/TopCard.tsx
+++ b/application/app/components/fiches/shared/TopCard.tsx
@@ -1,6 +1,6 @@
 // import Link from 'next/link';
 import { TopEtablissement } from '@/app/models/etablissements';
-import * as Tooltip from '@radix-ui/react-tooltip';
+import * as Popover from '@radix-ui/react-popover';
 import { Sun } from 'lucide-react';
 
 const UNKNOWN_TEXTS = {
@@ -28,33 +28,31 @@ const TopCard = ({ topEtablissements }: Props) => {
 				{topEtablissements.slice(0, 3).map((etab, index) => (
 					<li key={etab.id}>
 						{medals[index]}{' '}
-						<Tooltip.Provider>
-							<Tooltip.Root>
-								<Tooltip.Trigger asChild>
-									<span
+						<Popover.Root>
+							<Popover.Trigger asChild>
+								<span
 										className='hover:bg-gray-100 rounded text-darkgreen transition'
 										aria-disabled='true'
 									>
 										<span
-											// href={`/etablissements/${etab.id}`}
+											// href={/etablissements/${etab.id}}
 											aria-disabled='true'
 											className='underline decoration-dotted decoration-2 underline-offset-4 transition hover:text-primary'
 										>
 											{etab.libelle}
 										</span>
 									</span>
-								</Tooltip.Trigger>
-								<Tooltip.Portal>
-									<Tooltip.Content
-										className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
-										sideOffset={5}
-									>
-										Cette fonctionnalité n&apos;est pas encore disponible !
-										<Tooltip.Arrow className='fill-black' />
-									</Tooltip.Content>
-								</Tooltip.Portal>
-							</Tooltip.Root>
-						</Tooltip.Provider>
+							</Popover.Trigger>
+							<Popover.Portal>
+								<Popover.Content
+									className='z-50 rounded bg-blue px-3 py-1.5 text-xs text-white shadow'
+									sideOffset={5}
+								>
+									Cette fonctionnalité n&apos;est pas encore disponible !
+									<Popover.Arrow className='fill-black' />
+								</Popover.Content>
+							</Popover.Portal>
+						</Popover.Root>
 					</li>
 				))}
 			</ul>

--- a/application/app/components/fiches/shared/TopCard.tsx
+++ b/application/app/components/fiches/shared/TopCard.tsx
@@ -31,17 +31,17 @@ const TopCard = ({ topEtablissements }: Props) => {
 						<Popover.Root>
 							<Popover.Trigger asChild>
 								<span
-										className='hover:bg-gray-100 rounded text-darkgreen transition'
+									className='hover:bg-gray-100 rounded text-darkgreen transition'
+									aria-disabled='true'
+								>
+									<span
+										// href={/etablissements/${etab.id}}
 										aria-disabled='true'
+										className='underline decoration-dotted decoration-2 underline-offset-4 transition hover:text-primary'
 									>
-										<span
-											// href={/etablissements/${etab.id}}
-											aria-disabled='true'
-											className='underline decoration-dotted decoration-2 underline-offset-4 transition hover:text-primary'
-										>
-											{etab.libelle}
-										</span>
+										{etab.libelle}
 									</span>
+								</span>
 							</Popover.Trigger>
 							<Popover.Portal>
 								<Popover.Content


### PR DESCRIPTION
### Description

Cette PR a pour objectif de d'activer les tooltip même en vue mobile
<img width="346" height="615" alt="Capture d’écran 2025-07-16 à 23 41 33" src="https://github.com/user-attachments/assets/f1952bb9-fe9a-43b0-b3c1-a6d3fb150e24" />


### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
