### PR TITLE
fix: le flux IGN ADMINEXPRESS-COG.LATEST:arrondissement_municipal ne renvoie plus les mêmes noms de colonnes

### DIFF
--- a/algorithme/database/versions/2025_03_26_1549_add_arrondissements.py
+++ b/algorithme/database/versions/2025_03_26_1549_add_arrondissements.py
@@ -42,9 +42,9 @@ def upgrade() -> None:
             geom
         )
         SELECT
-            arr.insee_arm AS code_commune,
-            arr.nom AS nom_commune,
-            CONCAT('0', LPAD(arr.insee_arm, 2, '0')) AS code_departement,
+            arr.code_insee AS code_commune,
+            arr.nom_officiel AS nom_commune,
+            CONCAT('0', LPAD(arr.code_insee, 2, '0')) AS code_departement,
             NULL AS libelle_departement,
             NULL AS code_region,
             NULL AS libelle_region,
@@ -116,7 +116,7 @@ def upgrade() -> None:
         ) AS agg
         WHERE {communes_table}.code_commune = agg.code_commune
             AND ({communes_table}.code_commune IN (
-                    SELECT arr.insee_arm
+                    SELECT arr.code_insee
                     FROM ST_Read('{arrondissements_path}') arr
             ) OR {communes_table}.code_commune IN ('27676', '75105'))
     """)
@@ -138,7 +138,7 @@ def downgrade() -> None:
     op.execute(f"""
         DELETE FROM {communes_table}
         WHERE code_commune IN (
-            SELECT arr.insee_arm
+            SELECT arr.code_insee
             FROM ST_Read('{arrondissements_path}') arr
         )
     """)

--- a/algorithme/potentiel_solaire/sources/arrondissements.py
+++ b/algorithme/potentiel_solaire/sources/arrondissements.py
@@ -95,7 +95,7 @@ def remove_holes_and_overlap_for_cities(
     map_holes_to_arrondissements["overlap_arrondissement_avec_buffer"] = map_holes_to_arrondissements.to_crs(6933).apply(
         lambda hole: intersection(
             make_valid(hole["geometry"]), 
-            arrondissements_no_overlap[arrondissements_no_overlap["insee_arm"] == hole["insee_arm"]].to_crs(6933)["geometry"].buffer(50).iloc[0]
+            arrondissements_no_overlap[arrondissements_no_overlap["code_insee"] == hole["code_insee"]].to_crs(6933)["geometry"].buffer(50).iloc[0]
             ).area,
         axis=1
     )
@@ -107,12 +107,12 @@ def remove_holes_and_overlap_for_cities(
     arrondissements_no_overlap_no_holes = arrondissements_no_overlap.merge(
         map_holes_to_arrondissements,
         how="outer"
-    ).dissolve(by="insee_arm").reset_index()
+    ).dissolve(by="code_insee").reset_index()
     
     # On fait en sorte de n'avoir que des polygons valides
     arrondissements_no_overlap_no_holes["geometry"] = arrondissements_no_overlap_no_holes["geometry"].make_valid()
     arrondissements_no_overlap_no_holes = arrondissements_no_overlap_no_holes.explode()
-    arrondissements_no_overlap_no_holes = arrondissements_no_overlap_no_holes.dissolve(by="insee_arm").reset_index()
+    arrondissements_no_overlap_no_holes = arrondissements_no_overlap_no_holes.dissolve(by="code_insee").reset_index()
 
     return arrondissements_no_overlap_no_holes[arrondissements.columns]
 
@@ -124,7 +124,7 @@ def create_arrondissements_geojson(output_directory: str = DATA_FOLDER) -> str:
 
     sources = load_sources()
     communes = gpd.read_file(sources["communes"].filepath)
-    cities = communes[communes["codgeo"].isin(arrondissements["insee_com"].unique())]
+    cities = communes[communes["codgeo"].isin(arrondissements["code_insee_de_la_commune_de_rattach"].unique())]
 
     arrondissements_corrected = remove_holes_and_overlap_for_cities(
         arrondissements=arrondissements_simplified,


### PR DESCRIPTION
### Description
En partant d'un database vierge, la commande `alembic upgrade head` rentre en erreur.

```
arrondissements_path = create_arrondissements_geojson()

  File "/home/ronan/code/13_potentiel_solaire/algorithme/potentiel_solaire/sources/arrondissements.py", line 127, in create_arrondissements_geojson
    cities = communes[communes["codgeo"].isin(arrondissements["insee_com"].unique())]
```

Le flux IGN pour récupérer les arrondissements a changé, les noms de colonnes ne sont plus les mêmes : 
- `insee_arm` -> `code_insee`
- `nom `-> `nom_officiel`
- `insee_com` -> `code_insee_de_la_commune_de_rattach`

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'agorithme
- Je respecte au mieux la [PEP8](https://peps.python.org/pep-0008/) notamment sur la façon de nommer les classes, fonctions et variables
- Les arguments des fonctions sont typés
- Chaque nouvelle fonction a une docstring
- Je mets à jour les docstrings des fonctions que j'ai modifiée
- J'ai ajouté des commentaires dans le code qui expliquent **pourquoi** certaines opérations sont faites
- Les noms des fonctions & variables aident à la lecture et compréhension du code
- J'évite des fonctions qui prennent en argument des dataframes et renvoient celles-ci modifiées
- J'écrit des tests unitaires pour les fonctions les plus complexes
- Je consulte cette [page](../docs/algorithme_best_code_practices.md) si je veux avoir plus d'explications et d'exemples sur ces bonnes pratiques

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
