### PR TITLE
[FRONT] fix: adjust footer z-index

### DIFF
--- a/application/app/components/Footer.tsx
+++ b/application/app/components/Footer.tsx
@@ -13,7 +13,7 @@ export default function Footer() {
 	const [isOpen, setIsOpen] = useState(false);
 
 	return (
-		<footer className='fixed bottom-0 z-40 w-full bg-blue text-white' id='footer'>
+		<footer className='fixed bottom-0 z-50 w-full bg-blue text-white' id='footer'>
 			<div className='flex w-full items-center justify-center border-t border-green bg-blue py-2'>
 				<button
 					onClick={() => setIsOpen(!isOpen)}


### PR DESCRIPTION
### Description
Github issue : _240_

Cette PR a pour objectif de corriger le z-index du footer par rapport à la navbar.  our qu'il n'y ait pas de conflits sur les tous petits écrans. En alignant le z-index de la navbar et du footer on s'assure que l'élément actif prenne le pas sur l'autre.

### Comment tester ?
<img width="345" height="544" alt="Capture d’écran 2025-09-04 à 23 56 51" src="https://github.com/user-attachments/assets/c1e9d8a0-2960-4d7a-b434-cf8b48cefc7d" />


### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'agorithme
- Je respecte au mieux la [PEP8](https://peps.python.org/pep-0008/) notamment sur la façon de nommer les classes, fonctions et variables
- Les arguments des fonctions sont typés
- Chaque nouvelle fonction a une docstring
- Je mets à jour les docstrings des fonctions que j'ai modifiée
- J'ai ajouté des commentaires dans le code qui expliquent **pourquoi** certaines opérations sont faites
- Les noms des fonctions & variables aident à la lecture et compréhension du code
- J'évite des fonctions qui prennent en argument des dataframes et renvoient celles-ci modifiées
- J'écrit des tests unitaires pour les fonctions les plus complexes
- Je consulte cette [page](../docs/algorithme_best_code_practices.md) si je veux avoir plus d'explications et d'exemples sur ces bonnes pratiques

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
