### PR TITLE
feature/web-ci-pr-lint: add ci action to lint the Next application wh…

### DIFF
--- a/.github/workflows/ci-app-pr.yaml
+++ b/.github/workflows/ci-app-pr.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - "application/**"
-      - ".github/workflows/ci-app-pr.yml"
+      - ".github/workflows/ci-app-pr.yaml"
 
 jobs:
   build:


### PR DESCRIPTION
### Description
Github issue : N/A

Cette PR a pour objectif d'ajouter une action CI pour faire le lint de l'application Next sur une PR ciblant `main`.
Cela permet de détecter les erreurs en amont. (si le build n'a pas été fait avant la PR).

_Pour intégrer une action CI qui **build**, il aurait fallu ajouter le lien vers la database et donc se servir de l'image docker => on reste sur le lint simple._

### Comment tester ?
Faire une PR vers la branche main, constater qu'une action CI se lance et lint le code de l'application Next.

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
