### PR TITLE
fix: add fiche access button + fix etablissement zoom

### DIFF
--- a/application/app/components/Map/BackButton.tsx
+++ b/application/app/components/Map/BackButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { ChevronLeft } from 'lucide-react';
 
 type BackButtonProps = {
 	onBack: () => void;
@@ -6,8 +7,14 @@ type BackButtonProps = {
 
 export default function BackButton({ onBack }: BackButtonProps) {
 	return (
-		<Button onClick={onBack} className='absolute right-4 top-4'>
-			Retour
+		<Button
+			onClick={onBack}
+			className='flex items-center gap-2 rounded-md border border-white bg-blue text-sm shadow-md'
+			size='sm'
+			aria-label='Retour'
+		>
+			<ChevronLeft size={20} />
+			<span className='hidden sm:block'>Retour</span>
 		</Button>
 	);
 }

--- a/application/app/components/Map/CurrentLevel.tsx
+++ b/application/app/components/Map/CurrentLevel.tsx
@@ -1,0 +1,37 @@
+import { Commune } from '@/app/models/communes';
+import { Departement } from '@/app/models/departements';
+import { Etablissement } from '@/app/models/etablissements';
+import { Region } from '@/app/models/regions';
+import { getLevelName } from '@/app/utils/level-utils';
+import { Button } from '@/components/ui/button';
+import { Newspaper } from 'lucide-react';
+
+import { Level } from './interfaces';
+
+const LEVEL_TO_LABEL: Record<Exclude<Level, 'nation'>, string> = {
+	etablissement: 'Établissement',
+	commune: 'Commune',
+	departement: 'Département',
+	region: 'Région',
+};
+
+type CurrentLevelProps = {
+	level: Exclude<Level, 'nation'>;
+	levelItem: Region | Departement | Commune | Etablissement;
+	openFiche: (level: Exclude<Level, 'nation'>) => void;
+};
+
+export default function CurrentLevel({ level, levelItem, openFiche }: CurrentLevelProps) {
+	const nom = getLevelName(level, levelItem);
+	return (
+		<Button
+			onClick={() => openFiche(level)}
+			className='flex items-center gap-2 rounded-md border border-white bg-blue text-sm shadow-md'
+			size='sm'
+			aria-label={`Ouvrir la fiche de ${nom} (${LEVEL_TO_LABEL[level]})`}
+		>
+			{nom} {`(${LEVEL_TO_LABEL[level]})`}
+			<Newspaper size={20} />
+		</Button>
+	);
+}

--- a/application/app/components/Map/MapWithFiches.tsx
+++ b/application/app/components/Map/MapWithFiches.tsx
@@ -13,20 +13,22 @@ export default function MapWithFiches() {
 	const { etablissement, commune, departement, region, isFetching } = useSelectedPlaces();
 	const [isFicheOpen] = useActiveTab();
 
+	const selectedPlaces = { etablissement, commune, departement, region };
+
 	return (
 		<div className='flex flex-1 flex-col'>
 			<div className='relative flex-1'>
 				<Suspense>
 					<HomeOverlay />
-					<FranceMap />
+					<FranceMap selectedPlaces={selectedPlaces} />
 				</Suspense>
 			</div>
 			{isFicheOpen && (
 				<Fiches
-					commune={commune ?? undefined}
-					departement={departement ?? undefined}
-					region={region ?? undefined}
-					etablissement={etablissement ?? undefined}
+					commune={commune}
+					departement={departement}
+					region={region}
+					etablissement={etablissement}
 					isFetching={isFetching}
 				/>
 			)}

--- a/application/app/models/common.ts
+++ b/application/app/models/common.ts
@@ -1,3 +1,8 @@
+import { Commune } from './communes';
+import { Departement } from './departements';
+import { Etablissement } from './etablissements';
+import { Region } from './regions';
+
 //TODO: fetch from db at startup instead of hardcoding
 export const NIVEAUX_POTENTIELS = [
 	{ code: '1_HIGH', min: 250000, max: 999999999999 },
@@ -8,3 +13,10 @@ export const NIVEAUX_POTENTIELS = [
 export type NiveauPotentiel = (typeof NIVEAUX_POTENTIELS)[number]['code'];
 
 export type NbEtablissementsByNiveauPotentiel = Record<NiveauPotentiel, number>;
+
+export type SelectedPlaces = {
+	etablissement: Etablissement | undefined;
+	commune: Commune | undefined;
+	departement: Departement | undefined;
+	region: Region | undefined;
+};

--- a/application/app/utils/level-utils.ts
+++ b/application/app/utils/level-utils.ts
@@ -1,0 +1,24 @@
+import { Level } from '../components/Map/interfaces';
+import { SelectedPlaces } from '../models/common';
+import { Commune } from '../models/communes';
+import { Departement } from '../models/departements';
+import { Etablissement } from '../models/etablissements';
+import { Region } from '../models/regions';
+
+export function getCurrentLevelItem(level: Level, selectedPlaces: SelectedPlaces) {
+	if (level === 'nation') return null;
+	return selectedPlaces[level];
+}
+
+export function getLevelName(level: Level, item: Region | Departement | Commune | Etablissement) {
+	switch (level) {
+		case 'region':
+			return (item as Region).libelle_region;
+		case 'departement':
+			return (item as Departement).libelle_departement;
+		case 'commune':
+			return (item as Commune).nom_commune;
+		case 'etablissement':
+			return (item as Etablissement).nom_etablissement;
+	}
+}


### PR DESCRIPTION
### Description
Github issue : #240 

Cette PR a pour objectif de corriger les point suivants : 
- Bouton retour à mettre à gauche de la carte + afficher le niveau actuel (son nom) avec un bouton d'accès à la fiche associé 
- Bouton retour affiche une fleche simple sans le libellé (sur vue mobile) pour gagner de la place 
- ne pas zoomer trop quand on clique sur un etablissement

### Comment tester ?
Manipulation de la carte

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
