### PR TITLE
[FRONT] Only show tabs for loaded data

### DIFF
--- a/application/app/components/fiches/Fiches.tsx
+++ b/application/app/components/fiches/Fiches.tsx
@@ -98,14 +98,14 @@ export default function Fiches({
 	}
 
 	const tabs: Tab = [
-		{ id: 'region', label: LEVEL_TO_LABEL_SHORTENED['region'] },
-		{ id: 'departement', label: LEVEL_TO_LABEL_SHORTENED['departement'] },
-		{ id: 'commune', label: LEVEL_TO_LABEL_SHORTENED['commune'] },
-		{ id: 'etablissement', label: etablissement?.type_etablissement },
-	];
+    ...(region ? [{ id: 'region' as const, label: LEVEL_TO_LABEL_SHORTENED['region'] }] : []),
+    ...(departement ? [{ id: 'departement' as const, label: LEVEL_TO_LABEL_SHORTENED['departement'] }] : []),
+    ...(commune ? [{ id: 'commune' as const, label: LEVEL_TO_LABEL_SHORTENED['commune'] }] : []),
+    ...(etablissement ? [{ id: 'etablissement' as const, label: etablissement.type_etablissement }] : []),
+  ];
 
 	const filteredTabs = tabs.filter((tab) => tab.label !== undefined);
-
+  
 	return (
 		<div
 			ref={ficheContainerRef}

--- a/application/app/components/fiches/Fiches.tsx
+++ b/application/app/components/fiches/Fiches.tsx
@@ -110,8 +110,6 @@ export default function Fiches({
 			: []),
 	];
 
-	const filteredTabs = tabs.filter((tab) => tab.label !== undefined);
-
 	return (
 		<div
 			ref={ficheContainerRef}
@@ -124,11 +122,11 @@ export default function Fiches({
 				<X />
 			</button>
 			<div className='flex gap-1 pl-2'>
-				{filteredTabs.map((tab) => (
+				{tabs.map((tab) => (
 					<button
 						key={tab.id}
 						className={`truncate rounded-md px-4 py-2 text-xs font-bold md:text-sm ${activeTab === tab.id ? 'bg-blue font-bold text-green' : 'bg-green text-blue'}`}
-						style={{ flexBasis: `${(1 / filteredTabs.length) * 100}%` }}
+						style={{ flexBasis: `${(1 / tabs.length) * 100}%` }}
 						onClick={() => setActiveTab(tab.id)}
 					>
 						{tab.label}

--- a/application/app/components/fiches/Fiches.tsx
+++ b/application/app/components/fiches/Fiches.tsx
@@ -98,14 +98,20 @@ export default function Fiches({
 	}
 
 	const tabs: Tab = [
-    ...(region ? [{ id: 'region' as const, label: LEVEL_TO_LABEL_SHORTENED['region'] }] : []),
-    ...(departement ? [{ id: 'departement' as const, label: LEVEL_TO_LABEL_SHORTENED['departement'] }] : []),
-    ...(commune ? [{ id: 'commune' as const, label: LEVEL_TO_LABEL_SHORTENED['commune'] }] : []),
-    ...(etablissement ? [{ id: 'etablissement' as const, label: etablissement.type_etablissement }] : []),
-  ];
+		...(region ? [{ id: 'region' as const, label: LEVEL_TO_LABEL_SHORTENED['region'] }] : []),
+		...(departement
+			? [{ id: 'departement' as const, label: LEVEL_TO_LABEL_SHORTENED['departement'] }]
+			: []),
+		...(commune
+			? [{ id: 'commune' as const, label: LEVEL_TO_LABEL_SHORTENED['commune'] }]
+			: []),
+		...(etablissement
+			? [{ id: 'etablissement' as const, label: etablissement.type_etablissement }]
+			: []),
+	];
 
 	const filteredTabs = tabs.filter((tab) => tab.label !== undefined);
-  
+
 	return (
 		<div
 			ref={ficheContainerRef}


### PR DESCRIPTION
### Description
Github issue : _#292_

Cette PR a pour objectif de corriger l'affichage des fiches de collectivités pour ne montrer que les onglets des collectivités dont les données sont présentes au niveau auxquelles se trouvent l'utilisateur;

### Comment tester ?
<img width="1403" height="673" alt="Capture d’écran 2025-09-12 à 23 24 14" src="https://github.com/user-attachments/assets/253323d6-34d5-46c8-a7e7-a58902ea0e5d" />


### Pour faciliter la validation de ma PR
- [X] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [X] Les pre-commit passent
- [X] Les test unitaires passent
- [X] Le code modifié fonctionne en local
- [X] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
