### PR TITLE
fix: align selected button to left when menudrom is closed

### DIFF
--- a/application/app/components/Map/MenuDrom.tsx
+++ b/application/app/components/Map/MenuDrom.tsx
@@ -38,7 +38,7 @@ function MenuDrom() {
 	}
 
 	return (
-		<div className='mt-2 flex w-full max-w-sm flex-row justify-start gap-2 bg-transparent md:justify-center'>
+		<div className='mt-2 flex w-full max-w-sm flex-row justify-start gap-2 bg-transparent'>
 			<button onClick={() => setIsOpen(!isOpen)} className={buttonStyle}>
 				{isOpen ? (
 					<X color='white' />


### PR DESCRIPTION
### Description
Github issue : N/A

Cette PR a pour objectif de corriger l'emplacement du bouton DROM sélectionné lorsque le menu est replié.

### Comment tester ?

Avant : 
![Capture vidéo du 2025-09-13 14-28-46](https://github.com/user-attachments/assets/7d738e75-c07b-4e05-b0d9-9b0f34d4561a)

Après : 
![Capture vidéo du 2025-09-13 14-28-32](https://github.com/user-attachments/assets/444c456d-f395-441a-b877-582b5954779c)


### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
