### PR TITLE
Fix/web 240 show selected map element

### DIFF
--- a/application/app/components/Map/CurrentLevel.tsx
+++ b/application/app/components/Map/CurrentLevel.tsx
@@ -20,7 +20,7 @@ export default function CurrentLevel({ level, levelItem, openFiche }: CurrentLev
 	return (
 		<Button
 			onClick={() => openFiche(level)}
-			className='flex items-center gap-2 rounded-md border border-white bg-blue text-sm shadow-md'
+			className='flex items-center gap-2 rounded-md bg-green text-sm font-bold text-darkgreen shadow-md hover:bg-green hover:underline'
 			size='sm'
 			aria-label={`Ouvrir la fiche de ${nom} (${LEVEL_TO_LABEL[level]})`}
 		>

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	LayerProps,
 	Layer as LayerReactMapLibre,
@@ -58,9 +58,9 @@ import {
 	ETABLISSEMENTS_SOURCE_ID,
 	clusterCountLayer,
 	clusterLayer,
-	unclusteredPointLayer,
+	getUnclusteredPointLayer,
+	getUnclusteredPointProtegeLayer,
 	unclusteredPointProtegeIconLayer,
-	unclusteredPointProtegeLayer,
 } from './layers/etablissementsLayers';
 import {
 	REGIONS_LABELS_SOURCE_ID,
@@ -423,6 +423,16 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 		isEtablissementsGeoJSONFetching;
 
 	const isEtablissementsLayerVisible = isCommuneLevel || isEtablissementLevel;
+
+	const unclusteredPointLayer = useMemo(
+		() => getUnclusteredPointLayer(codeEtablissement ?? null),
+		[codeEtablissement],
+	);
+
+	const unclusteredPointProtegeLayer = useMemo(
+		() => getUnclusteredPointProtegeLayer(codeEtablissement ?? null),
+		[codeEtablissement],
+	);
 
 	return (
 		<div className='relative flex h-full w-full flex-col'>

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -454,7 +454,7 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 				}}
 				{...interact(isInteractive)}
 			>
-				<NavigationControl position='top-left' />
+				<NavigationControl position='top-left' showCompass={false} />
 				{regionsGeoJSON && (
 					<Source
 						key={REGIONS_SOURCE_ID}

--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -1,4 +1,5 @@
 import {
+	ETABLISSEMENT_GEOJSON_KEY_ID,
 	ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE,
 	ETABLISSEMENT_GEOJSON_KEY_PROTECTION,
 } from '@/app/models/etablissements';
@@ -31,45 +32,85 @@ export const clusterCountLayer = {
 	},
 } satisfies LayerProps;
 
-export const unclusteredPointLayer = {
-	id: 'unclustered-point',
-	type: 'circle',
-	source: ETABLISSEMENTS_SOURCE_ID,
-	filter: [
-		'all',
-		['!', ['has', 'point_count']],
-		['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], false],
-	],
-	paint: {
-		'circle-color': [
-			'step',
-			['get', ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE],
-			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
-		],
-		'circle-radius': 15,
-	},
-} satisfies LayerProps;
+const POINT_RADIUS = 18;
+const DEFAULT_POINT_STROKE_WIDTH = 0;
+const SELECTED_POINT_STROKE_WIDTH = 10;
+const SELECTED_POINT_STROKE_COLOR = '#231c3f'; //the main palette blue color
+const SELECTED_POINT_STROKE_OPACITY = 0.6;
 
-export const unclusteredPointProtegeLayer = {
-	id: 'unclustered-point-protege',
-	type: 'circle',
-	source: ETABLISSEMENTS_SOURCE_ID,
-	filter: [
-		'all',
-		['!', ['has', 'point_count']],
-		['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], true],
-	],
-	paint: {
-		'circle-color': [
-			'step',
-			['get', ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE],
-			...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
+/**
+ * If there is a selected etablissement we add a halo around the point.
+ * If stroke width = 0 the stroke is not displayed so we only handle differences between selection or not in stroke-width property.
+ * @param selectedEtablissementId
+ * @returns
+ */
+export function getUnclusteredPointLayer(selectedEtablissementId: string | null) {
+	return {
+		id: 'unclustered-point',
+		type: 'circle',
+		source: ETABLISSEMENTS_SOURCE_ID,
+		filter: [
+			'all',
+			['!', ['has', 'point_count']],
+			['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], false],
 		],
-		'circle-radius': 15,
-		'circle-stroke-width': 2,
-		'circle-stroke-color': '#221c3e',
-	},
-} satisfies LayerProps;
+		paint: {
+			'circle-color': [
+				'step',
+				['get', ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE],
+				...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
+			],
+			'circle-radius': POINT_RADIUS,
+			// add selected halo
+			'circle-stroke-width': [
+				'match',
+				['get', ETABLISSEMENT_GEOJSON_KEY_ID],
+				selectedEtablissementId ?? '',
+				SELECTED_POINT_STROKE_WIDTH,
+				DEFAULT_POINT_STROKE_WIDTH,
+			],
+			'circle-stroke-color': SELECTED_POINT_STROKE_COLOR,
+			'circle-stroke-opacity': SELECTED_POINT_STROKE_OPACITY,
+		},
+	} satisfies LayerProps;
+}
+
+/**
+ * If there is a selected etablissement we add a halo around the point.
+ * If stroke width = 0 the stroke is not displayed so we only handle differences between selection or not in stroke-width property.
+ * @param selectedEtablissementId
+ * @returns
+ */
+export function getUnclusteredPointProtegeLayer(selectedEtablissementId: string | null) {
+	return {
+		id: 'unclustered-point-protege',
+		type: 'circle',
+		source: ETABLISSEMENTS_SOURCE_ID,
+		filter: [
+			'all',
+			['!', ['has', 'point_count']],
+			['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], true],
+		],
+		paint: {
+			'circle-color': [
+				'step',
+				['get', ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE],
+				...thresholdsToStepColorsParams(COLOR_THRESHOLDS.commune),
+			],
+			'circle-radius': POINT_RADIUS,
+			// add selected halo
+			'circle-stroke-width': [
+				'match',
+				['get', ETABLISSEMENT_GEOJSON_KEY_ID],
+				selectedEtablissementId ?? '',
+				SELECTED_POINT_STROKE_WIDTH,
+				DEFAULT_POINT_STROKE_WIDTH,
+			],
+			'circle-stroke-opacity': SELECTED_POINT_STROKE_OPACITY,
+			'circle-stroke-color': SELECTED_POINT_STROKE_COLOR,
+		},
+	} satisfies LayerProps;
+}
 
 export const unclusteredPointProtegeIconLayer = {
 	id: 'unclustered-point-protege-icon',

--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -36,7 +36,7 @@ const POINT_RADIUS = 18;
 const DEFAULT_POINT_STROKE_WIDTH = 0;
 const SELECTED_POINT_STROKE_WIDTH = 10;
 const SELECTED_POINT_STROKE_COLOR = '#231c3f'; //the main palette blue color
-const SELECTED_POINT_STROKE_OPACITY = 0.6;
+const SELECTED_POINT_STROKE_OPACITY = 0.8;
 
 /**
  * If there is a selected etablissement we add a halo around the point.

--- a/application/app/models/etablissements.ts
+++ b/application/app/models/etablissements.ts
@@ -58,6 +58,8 @@ export type EtablissementsGeoJSON = GeoJSON.FeatureCollection<
 export type EtablissementFeature = EtablissementsGeoJSON['features'][number];
 
 // Reference keys for proper access with maplibre layer properties
+export const ETABLISSEMENT_GEOJSON_KEY_ID: keyof EtablissementFeatureProperties =
+	'identifiant_de_l_etablissement';
 export const ETABLISSEMENT_GEOJSON_KEY_PROTECTION: keyof EtablissementFeatureProperties =
 	'protection';
 export const ETABLISSEMENT_GEOJSON_KEY_POTENTIEL_SOLAIRE: keyof EtablissementFeatureProperties =


### PR DESCRIPTION
### Description
Github issue : #240 

Cette PR a pour objectif d'afficher l'établissement sélectionné avec un halo.
La couleur du bouton d'accès à la fiche a également été modifié suite à un retour UI.
Les options qui permettent de tourner la carte seront désactivées par défaut sur une PR suivante: on enlève donc le bouton qui permettait de remettre la carte vers le Nord (cela gagne de la place).

### Comment tester ?
<img width="1902" height="866" alt="image" src="https://github.com/user-attachments/assets/8e3893df-6318-41e8-baf7-2e954e6cf948" />


### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [ ] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)