### PR TITLE
Fix/web 240 show selected zone

### DIFF
--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -44,8 +44,8 @@ import {
 	COMMUNES_SOURCE_ID,
 	communesLabelsLayer,
 	communesLayer,
-	communesLineLayer,
 	communesTransparentLayer,
+	getCommunesLineLayer,
 } from './layers/communesLayers';
 import {
 	DEPARTEMENTS_LABELS_SOURCE_ID,
@@ -53,6 +53,7 @@ import {
 	departementsBackgroundLayer,
 	departementsLabelsLayer,
 	departementsLayer,
+	getDepartementsLineLayer,
 } from './layers/departementsLayers';
 import {
 	ETABLISSEMENTS_SOURCE_ID,
@@ -65,6 +66,7 @@ import {
 import {
 	REGIONS_LABELS_SOURCE_ID,
 	REGIONS_SOURCE_ID,
+	getRegionsLineLayer,
 	regionsBackgroundLayer,
 	regionsLabelsLayer,
 	regionsLayer,
@@ -416,6 +418,18 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 
 	const isEtablissementsLayerVisible = isCommuneLevel || isEtablissementLevel;
 
+	// Memorized layers with dynamic props
+	const regionsLineLayer = useMemo(() => getRegionsLineLayer(codeRegion ?? null), [codeRegion]);
+
+	const departementLineLayer = useMemo(
+		() => getDepartementsLineLayer(codeDepartement ?? null),
+		[codeDepartement],
+	);
+	const communesLineLayer = useMemo(
+		() => getCommunesLineLayer(codeCommune ?? null),
+		[codeCommune],
+	);
+
 	const unclusteredPointLayer = useMemo(
 		() => getUnclusteredPointLayer(codeEtablissement ?? null),
 		[codeEtablissement],
@@ -469,6 +483,7 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 						) : (
 							<LayerReactMapLibre {...regionsBackgroundLayer} />
 						)}
+						{!isNationLevel && <LayerReactMapLibre {...regionsLineLayer} />}
 					</Source>
 				)}
 				{regionLabelPoints && (
@@ -491,6 +506,9 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 						{isRegionLevel && <LayerReactMapLibre {...departementsLayer} />}
 						{isDepartementLevel && (
 							<LayerReactMapLibre {...departementsBackgroundLayer} />
+						)}
+						{!isNationLevel && !isRegionLevel && (
+							<LayerReactMapLibre {...departementLineLayer} />
 						)}
 					</Source>
 				)}

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -493,7 +493,7 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 						type='geojson'
 						data={regionLabelPoints}
 					>
-						{isNationLevel && <LayerReactMapLibre {...regionsLabelsLayer} />}
+						<LayerReactMapLibre {...regionsLabelsLayer} />
 					</Source>
 				)}
 				{departementsGeoJSON && (
@@ -519,7 +519,7 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 						type='geojson'
 						data={departementLabelPoints}
 					>
-						{isRegionLevel && <LayerReactMapLibre {...departementsLabelsLayer} />}
+						<LayerReactMapLibre {...departementsLabelsLayer} />
 					</Source>
 				)}
 				{communesGeoJSON && (
@@ -545,7 +545,7 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 						type='geojson'
 						data={communeLabelPoints}
 					>
-						{isDepartementLevel && <LayerReactMapLibre {...communesLabelsLayer} />}
+						<LayerReactMapLibre {...communesLabelsLayer} />
 					</Source>
 				)}
 				{etablissementsGeoJSON && (

--- a/application/app/components/Map/layers/communesLayers.ts
+++ b/application/app/components/Map/layers/communesLayers.ts
@@ -1,6 +1,6 @@
 import { LayerProps } from 'react-map-gl/maplibre';
 
-import { COMMUNE_GEOJSON_KEY_NOM } from '@/app/models/communes';
+import { COMMUNE_GEOJSON_KEY_ID, COMMUNE_GEOJSON_KEY_NOM } from '@/app/models/communes';
 
 import { COLOR_THRESHOLDS } from '../constants';
 import { zonesLayerPaint } from './zonesLayersPaint';
@@ -13,7 +13,6 @@ export const communesLayer = {
 	type: 'fill',
 	source: COMMUNES_SOURCE_ID,
 	paint: zonesLayerPaint(COLOR_THRESHOLDS.departement, false),
-	maxzoom: 11,
 } satisfies LayerProps;
 
 // Used to be able to click
@@ -24,12 +23,34 @@ export const communesTransparentLayer = {
 	paint: { 'fill-color': 'transparent' },
 } satisfies LayerProps;
 
-export const communesLineLayer = {
-	id: 'communesLine',
-	type: 'line',
-	source: COMMUNES_SOURCE_ID,
-	paint: { 'line-color': 'grey', 'line-width': 1 },
-} satisfies LayerProps;
+const DEFAULT_ZONE_LINE_WIDTH = 2;
+const DEFAULT_ZONE_LINE_COLOR = 'grey';
+const SELECTED_ZONE_LINE_WIDTH = 6;
+const SELECTED_ZONE_LINE_COLOR = 'white';
+
+export function getCommunesLineLayer(selectedCommuneId: string | null) {
+	return {
+		id: 'communes-line',
+		type: 'line',
+		source: COMMUNES_SOURCE_ID,
+		paint: {
+			'line-color': [
+				'match',
+				['get', COMMUNE_GEOJSON_KEY_ID],
+				selectedCommuneId ?? '',
+				SELECTED_ZONE_LINE_COLOR,
+				DEFAULT_ZONE_LINE_COLOR,
+			],
+			'line-width': [
+				'match',
+				['get', COMMUNE_GEOJSON_KEY_ID],
+				selectedCommuneId ?? '',
+				SELECTED_ZONE_LINE_WIDTH,
+				DEFAULT_ZONE_LINE_WIDTH,
+			],
+		},
+	} satisfies LayerProps;
+}
 
 export const communesLabelsLayer = {
 	id: 'communes-labels',

--- a/application/app/components/Map/layers/communesLayers.ts
+++ b/application/app/components/Map/layers/communesLayers.ts
@@ -3,25 +3,31 @@ import { LayerProps } from 'react-map-gl/maplibre';
 import { COMMUNE_GEOJSON_KEY_ID, COMMUNE_GEOJSON_KEY_NOM } from '@/app/models/communes';
 
 import { COLOR_THRESHOLDS } from '../constants';
-import { zonesLayerPaint } from './zonesLayersPaint';
+import { zonesLayerFillOpacity, zonesLayerPaint } from './zonesLayersPaint';
 
 export const COMMUNES_SOURCE_ID = 'communes';
 export const COMMUNES_LABELS_SOURCE_ID = 'communes-labels';
 
-export const communesLayer = {
-	id: 'communes',
-	type: 'fill',
-	source: COMMUNES_SOURCE_ID,
-	paint: zonesLayerPaint(COLOR_THRESHOLDS.departement, false),
-} satisfies LayerProps;
-
-// Used to be able to click
-export const communesTransparentLayer = {
-	id: 'communesTransparent',
-	type: 'fill',
-	source: COMMUNES_SOURCE_ID,
-	paint: { 'fill-color': 'transparent' },
-} satisfies LayerProps;
+export function getCommunesLayer(
+	selectedCommuneId: string | null,
+	isLastLevel: boolean,
+	isBackground: boolean,
+) {
+	return {
+		id: 'communes',
+		type: 'fill',
+		source: COMMUNES_SOURCE_ID,
+		paint: {
+			...zonesLayerPaint(COLOR_THRESHOLDS.departement),
+			...zonesLayerFillOpacity(
+				COMMUNE_GEOJSON_KEY_ID,
+				selectedCommuneId,
+				isLastLevel,
+				isBackground,
+			),
+		},
+	} satisfies LayerProps;
+}
 
 const DEFAULT_ZONE_LINE_WIDTH = 2;
 const DEFAULT_ZONE_LINE_COLOR = 'grey';

--- a/application/app/components/Map/layers/departementsLayers.ts
+++ b/application/app/components/Map/layers/departementsLayers.ts
@@ -1,6 +1,6 @@
 import { LayerProps } from 'react-map-gl/maplibre';
 
-import { DEPARTEMENT_GEOJSON_KEY_NOM } from '@/app/models/departements';
+import { DEPARTEMENT_GEOJSON_KEY_ID, DEPARTEMENT_GEOJSON_KEY_NOM } from '@/app/models/departements';
 
 import { COLOR_THRESHOLDS } from '../constants';
 import { zonesLayerPaint } from './zonesLayersPaint';
@@ -14,12 +14,33 @@ function getDepartementsLayer(isBackground = false) {
 		type: 'fill',
 		source: DEPARTEMENTS_SOURCE_ID,
 		paint: zonesLayerPaint(COLOR_THRESHOLDS.region, isBackground),
-		maxzoom: 11,
 	} satisfies LayerProps;
 }
 
 export const departementsLayer = getDepartementsLayer();
 export const departementsBackgroundLayer = getDepartementsLayer(true);
+
+const DEFAULT_ZONE_LINE_WIDTH = 0;
+const SELECTED_ZONE_LINE_WIDTH = 6;
+
+export function getDepartementsLineLayer(selectedDepartementId: string | null) {
+	return {
+		id: 'departements-line',
+		type: 'line',
+		source: DEPARTEMENTS_SOURCE_ID,
+		paint: {
+			'line-color': 'white',
+			'line-width': [
+				'match',
+				['get', DEPARTEMENT_GEOJSON_KEY_ID],
+				selectedDepartementId ?? '',
+				SELECTED_ZONE_LINE_WIDTH,
+				DEFAULT_ZONE_LINE_WIDTH,
+			],
+			// 'line-opacity': 0.5,
+		},
+	} satisfies LayerProps;
+}
 
 export const departementsLabelsLayer = {
 	id: 'departements-labels',

--- a/application/app/components/Map/layers/departementsLayers.ts
+++ b/application/app/components/Map/layers/departementsLayers.ts
@@ -3,22 +3,31 @@ import { LayerProps } from 'react-map-gl/maplibre';
 import { DEPARTEMENT_GEOJSON_KEY_ID, DEPARTEMENT_GEOJSON_KEY_NOM } from '@/app/models/departements';
 
 import { COLOR_THRESHOLDS } from '../constants';
-import { zonesLayerPaint } from './zonesLayersPaint';
+import { zonesLayerFillOpacity, zonesLayerPaint } from './zonesLayersPaint';
 
 export const DEPARTEMENTS_SOURCE_ID = 'departements';
 export const DEPARTEMENTS_LABELS_SOURCE_ID = 'departements-labels';
 
-function getDepartementsLayer(isBackground = false) {
+export function getDepartementsLayer(
+	selectedDepartementId: string | null,
+	isLastLevel: boolean,
+	isBackground: boolean,
+) {
 	return {
 		id: 'departements',
 		type: 'fill',
 		source: DEPARTEMENTS_SOURCE_ID,
-		paint: zonesLayerPaint(COLOR_THRESHOLDS.region, isBackground),
+		paint: {
+			...zonesLayerPaint(COLOR_THRESHOLDS.region),
+			...zonesLayerFillOpacity(
+				DEPARTEMENT_GEOJSON_KEY_ID,
+				selectedDepartementId,
+				isLastLevel,
+				isBackground,
+			),
+		},
 	} satisfies LayerProps;
 }
-
-export const departementsLayer = getDepartementsLayer();
-export const departementsBackgroundLayer = getDepartementsLayer(true);
 
 const DEFAULT_ZONE_LINE_WIDTH = 0;
 const SELECTED_ZONE_LINE_WIDTH = 6;
@@ -37,7 +46,6 @@ export function getDepartementsLineLayer(selectedDepartementId: string | null) {
 				SELECTED_ZONE_LINE_WIDTH,
 				DEFAULT_ZONE_LINE_WIDTH,
 			],
-			// 'line-opacity': 0.5,
 		},
 	} satisfies LayerProps;
 }

--- a/application/app/components/Map/layers/regionsLayers.ts
+++ b/application/app/components/Map/layers/regionsLayers.ts
@@ -1,6 +1,6 @@
 import { LayerProps } from 'react-map-gl/maplibre';
 
-import { REGIONS_GEOJSON_KEY_NOM } from '@/app/models/regions';
+import { REGIONS_GEOJSON_KEY_ID, REGIONS_GEOJSON_KEY_NOM } from '@/app/models/regions';
 
 import { COLOR_THRESHOLDS } from '../constants';
 import { zonesLayerPaint } from './zonesLayersPaint';
@@ -14,12 +14,33 @@ function getRegionsLayer(isBackground = false) {
 		type: 'fill',
 		source: REGIONS_SOURCE_ID,
 		paint: zonesLayerPaint(COLOR_THRESHOLDS.nation, isBackground),
-		maxzoom: 10,
 	} satisfies LayerProps;
 }
 
 export const regionsLayer = getRegionsLayer();
 export const regionsBackgroundLayer = getRegionsLayer(true);
+
+const DEFAULT_ZONE_LINE_WIDTH = 0;
+const SELECTED_ZONE_LINE_WIDTH = 6;
+
+export function getRegionsLineLayer(selectedRegionId: string | null) {
+	return {
+		id: 'regions-line',
+		type: 'line',
+		source: REGIONS_SOURCE_ID,
+		paint: {
+			'line-color': 'white',
+			'line-width': [
+				'match',
+				['get', REGIONS_GEOJSON_KEY_ID],
+				selectedRegionId ?? '',
+				SELECTED_ZONE_LINE_WIDTH,
+				DEFAULT_ZONE_LINE_WIDTH,
+			],
+			// 'line-opacity': 0.5,
+		},
+	} satisfies LayerProps;
+}
 
 export const regionsLabelsLayer = {
 	id: 'regions-labels',

--- a/application/app/components/Map/layers/regionsLayers.ts
+++ b/application/app/components/Map/layers/regionsLayers.ts
@@ -3,22 +3,31 @@ import { LayerProps } from 'react-map-gl/maplibre';
 import { REGIONS_GEOJSON_KEY_ID, REGIONS_GEOJSON_KEY_NOM } from '@/app/models/regions';
 
 import { COLOR_THRESHOLDS } from '../constants';
-import { zonesLayerPaint } from './zonesLayersPaint';
+import { zonesLayerFillOpacity, zonesLayerPaint } from './zonesLayersPaint';
 
 export const REGIONS_SOURCE_ID = 'regions';
 export const REGIONS_LABELS_SOURCE_ID = 'regions-labels';
 
-function getRegionsLayer(isBackground = false) {
+export function getRegionsLayer(
+	selectedRegionId: string | null,
+	isLastLevel: boolean,
+	isBackground: boolean,
+) {
 	return {
 		id: 'regions',
 		type: 'fill',
 		source: REGIONS_SOURCE_ID,
-		paint: zonesLayerPaint(COLOR_THRESHOLDS.nation, isBackground),
+		paint: {
+			...zonesLayerPaint(COLOR_THRESHOLDS.nation),
+			...zonesLayerFillOpacity(
+				REGIONS_GEOJSON_KEY_ID,
+				selectedRegionId,
+				isLastLevel,
+				isBackground,
+			),
+		},
 	} satisfies LayerProps;
 }
-
-export const regionsLayer = getRegionsLayer();
-export const regionsBackgroundLayer = getRegionsLayer(true);
 
 const DEFAULT_ZONE_LINE_WIDTH = 0;
 const SELECTED_ZONE_LINE_WIDTH = 6;
@@ -37,7 +46,6 @@ export function getRegionsLineLayer(selectedRegionId: string | null) {
 				SELECTED_ZONE_LINE_WIDTH,
 				DEFAULT_ZONE_LINE_WIDTH,
 			],
-			// 'line-opacity': 0.5,
 		},
 	} satisfies LayerProps;
 }

--- a/application/app/components/Map/layers/zonesLayersPaint.ts
+++ b/application/app/components/Map/layers/zonesLayersPaint.ts
@@ -11,12 +11,51 @@ const ZONE_GEOJSON_KEY_POTENTIEL_SOLAIRE_TOTAL =
 		keyof CommuneFeatureProperties &
 		keyof RegionFeatureProperties;
 
-export function zonesLayerPaint(thresholds: Thresholds, isBackground: boolean) {
+/**
+ * Get the fill paint color properties for a zone layer.
+ * We map the color based on level thresholds.
+ * @param thresholds
+ * @returns
+ */
+export function zonesLayerPaint(thresholds: Thresholds) {
 	const fillColors = thresholdsToStepColorsParams(thresholds);
 
 	return {
 		'fill-color': ['step', ['get', ZONE_GEOJSON_KEY_POTENTIEL_SOLAIRE_TOTAL], ...fillColors],
-		'fill-opacity': isBackground ? 0.5 : 1,
 		'fill-outline-color': 'black',
+	} satisfies FillLayerSpecification['paint'];
+}
+
+/**
+ * Get the fill paint opacity for a zone layer.
+ * @param key the geojson property key to use for matching
+ * @param value the value of the geojson property key to match
+ * @param isLastLevel if true, the map is at the last level (etablissements)
+ * @param isBackground if true, the zone is in the background
+ * @returns
+ */
+export function zonesLayerFillOpacity(
+	key: string,
+	value: string | null,
+	isLastLevel: boolean,
+	isBackground: boolean,
+) {
+	/**
+	 * If the zone has been selected but is the last level (etablissements) we want to hide it.
+	 * In that case, in order to properly see the streets at etablissements level, we must hide every zone to have no fill from highest to lowest levels.
+	 * selectedZoneOpacity: the zone has been selected and is part of a previous level
+	 * notSelectedZoneOpacity: the zone is the currently displayed level and is the next level available for selection
+	 * isBackground = true means that the zone is adjacent to the selected zone stack and is not focused
+	 */
+	const selectedZoneOpacity = isLastLevel ? 0 : 0.5;
+	const notSelectedZoneOpacity = isBackground ? 0.5 : 1;
+	return {
+		'fill-opacity': [
+			'match',
+			['get', key],
+			value ?? '',
+			selectedZoneOpacity,
+			notSelectedZoneOpacity,
+		],
 	} satisfies FillLayerSpecification['paint'];
 }

--- a/application/app/models/communes.ts
+++ b/application/app/models/communes.ts
@@ -42,4 +42,5 @@ export type CommunesGeoJSON = GeoJSON.FeatureCollection<
 >;
 
 // Reference keys for proper access with maplibre layer properties
+export const COMMUNE_GEOJSON_KEY_ID: keyof CommuneFeatureProperties = 'code_commune';
 export const COMMUNE_GEOJSON_KEY_NOM: keyof CommuneFeatureProperties = 'nom_commune';

--- a/application/app/models/departements.ts
+++ b/application/app/models/departements.ts
@@ -39,5 +39,6 @@ export type DepartementsGeoJSON = GeoJSON.FeatureCollection<
 >;
 
 // Reference keys for proper access with maplibre layer properties
+export const DEPARTEMENT_GEOJSON_KEY_ID: keyof DepartementFeatureProperties = 'code_departement';
 export const DEPARTEMENT_GEOJSON_KEY_NOM: keyof DepartementFeatureProperties =
 	'libelle_departement';

--- a/application/app/models/regions.ts
+++ b/application/app/models/regions.ts
@@ -33,4 +33,5 @@ export type RegionFeature = RegionsGeoJSON['features'][number];
 export type RegionsGeoJSON = GeoJSON.FeatureCollection<GeoJSON.Polygon, RegionFeatureProperties>;
 
 // Reference keys for proper access with maplibre layer properties
+export const REGIONS_GEOJSON_KEY_ID: keyof RegionFeatureProperties = 'code_region';
 export const REGIONS_GEOJSON_KEY_NOM: keyof RegionFeatureProperties = 'libelle_region';


### PR DESCRIPTION
### Description
Github issue : #240 

Cette PR a pour objectif d'afficher un halo autour de la zone sélectionnée.
Garder la vue établissements dégagés pour voir les rues (en bleu donc), tout en gardant les couleurs de potentiel des communes adjacentes.
Affichage des labels de tous les niveaux affichés.
Ajout d'options par défaut pour la carte (minZoom, maxZoom) + autorisation de l'interactivité de toutes les couches (zoom, etc.)
+ Fix warning useEffect missing dependency 

### Comment tester ?
<img width="1926" height="872" alt="image" src="https://github.com/user-attachments/assets/45583108-723c-482b-8360-bd76121e142c" />


### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [ ] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)