### PR TITLE
[FRONT] Fix accordion title

### DIFF
--- a/application/app/comment-agir/page.tsx
+++ b/application/app/comment-agir/page.tsx
@@ -15,7 +15,7 @@ import AccordionCard from '../components/fiches/shared/AccordionCard';
 
 const actionsLong = [
 	{
-		title: 'Je suis un·e élu·e et je veux agir',
+		title: 'Je suis un élu ou une élue et je veux agir',
 		content: (
 			<>
 				{ELU_INTRO_LONG}
@@ -24,7 +24,7 @@ const actionsLong = [
 		),
 	},
 	{
-		title: 'Je suis un·e citoyen·ne et je veux agir',
+		title: 'Je suis un citoyen ou une citoyenne et je veux agir',
 		content: (
 			<>
 				{PARTICULIER_INTRO_LONG}

--- a/application/app/components/fiches/Fiches.tsx
+++ b/application/app/components/fiches/Fiches.tsx
@@ -21,11 +21,11 @@ import AccordionCard from './shared/AccordionCard';
 
 const actionsShort = [
 	{
-		title: 'Je suis un élu et je veux agir',
+		title: 'Je suis un élu ou une élue et je veux agir',
 		content: <>{ELU_BODY}</>,
 	},
 	{
-		title: 'Je suis un particulier et je veux agir',
+		title: 'Je suis un citoyen ou une citoyenne et je veux agir',
 		content: (
 			<>
 				{PARTICULIER_BODY}


### PR DESCRIPTION
### Description
Github issue : _#319_

Cette PR a pour objectif de corriger le titre des accordéons après accord avec GP

### Comment tester ?

<img width="1384" height="669" alt="Capture d’écran 2025-09-18 à 19 26 29" src="https://github.com/user-attachments/assets/2d1288b9-3c59-4a6b-b0fd-6c2f0f7911c5" />


### Pour faciliter la validation de ma PR
- [X] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [X] Les pre-commit passent
- [X] Les test unitaires passent
- [X] Le code modifié fonctionne en local
- [X] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
