### PR TITLE
fix: update zone halo width + commune label at etablissement level

### DIFF
--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -43,7 +43,7 @@ import { ClusterFeature, Layer, Level } from './interfaces';
 import {
 	COMMUNES_LABELS_SOURCE_ID,
 	COMMUNES_SOURCE_ID,
-	communesLabelsLayer,
+	getCommunesLabelLayer,
 	getCommunesLayer,
 	getCommunesLineLayer,
 } from './layers/communesLayers';
@@ -484,6 +484,11 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 		[codeCommune],
 	);
 
+	const communesLabelLayer = useMemo(
+		() => getCommunesLabelLayer(isEtablissementsLayerVisible),
+		[isEtablissementsLayerVisible],
+	);
+
 	const unclusteredPointLayer = useMemo(
 		() => getUnclusteredPointLayer(codeEtablissement ?? null),
 		[codeEtablissement],
@@ -593,7 +598,7 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 						type='geojson'
 						data={communeLabelPoints}
 					>
-						<LayerReactMapLibre {...communesLabelsLayer} />
+						<LayerReactMapLibre {...communesLabelLayer} />
 					</Source>
 				)}
 				{etablissementsGeoJSON && (

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -134,9 +134,10 @@ function isFeatureFrom<T extends EventFeature>(
 
 interface FranceMapProps {
 	selectedPlaces: SelectedPlaces;
+	hideToolbar?: boolean;
 }
 
-export default function FranceMap({ selectedPlaces }: FranceMapProps) {
+export default function FranceMap({ selectedPlaces, hideToolbar }: FranceMapProps) {
 	const mapRef = useRef<MapRef>(null);
 
 	/**
@@ -533,7 +534,7 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 				{...DEFAULT_INTERACTIVITY_CONFIG}
 				{...DEFAULT_ZOOM_CONSTRAINT}
 			>
-				<NavigationControl position='top-left' showCompass={false} />
+				{!hideToolbar && <NavigationControl position='top-left' showCompass={false} />}
 				{regionsGeoJSON && (
 					<Source
 						key={REGIONS_SOURCE_ID}
@@ -632,12 +633,14 @@ export default function FranceMap({ selectedPlaces }: FranceMapProps) {
 						)}
 					</Source>
 				)}
-				<div className='z-legend absolute inset-x-0 bottom-24 flex flex-col items-start justify-center px-4 md:flex-row md:items-center md:justify-center md:gap-4'>
+				{!hideToolbar && (
+					<div className='absolute inset-x-0 bottom-24 z-legend flex flex-col items-start justify-center px-4 md:flex-row md:items-center md:justify-center md:gap-4'>
 					<Legend thresholds={COLOR_THRESHOLDS[level]} />
 					<MenuDrom />
 				</div>
+				)}
 			</MapFromReactMapLibre>
-			{!isNationLevel && (
+			{!hideToolbar && !isNationLevel && (
 				<div className='absolute left-11 top-2 flex max-w-[calc(100%-3rem)] gap-1 overflow-hidden'>
 					<BackButton onBack={goBackOneLevel} previousLevel={getLayerUp().level} />
 					{currentLevelItem && (

--- a/application/app/components/Map/FranceMap.tsx
+++ b/application/app/components/Map/FranceMap.tsx
@@ -50,7 +50,7 @@ import {
 import {
 	DEPARTEMENTS_LABELS_SOURCE_ID,
 	DEPARTEMENTS_SOURCE_ID,
-	departementsLabelsLayer,
+	getDepartementsLabelsLayer,
 	getDepartementsLayer,
 	getDepartementsLineLayer,
 } from './layers/departementsLayers';
@@ -65,9 +65,9 @@ import {
 import {
 	REGIONS_LABELS_SOURCE_ID,
 	REGIONS_SOURCE_ID,
+	getRegionsLabelsLayer,
 	getRegionsLayer,
 	getRegionsLineLayer,
-	regionsLabelsLayer,
 } from './layers/regionsLayers';
 
 const MAP_STYLE_URL = `/map-styles/map-style.json`;
@@ -456,6 +456,11 @@ export default function FranceMap({ selectedPlaces, hideToolbar }: FranceMapProp
 	);
 	const regionsLineLayer = useMemo(() => getRegionsLineLayer(codeRegion ?? null), [codeRegion]);
 
+	const regionsLabelsLayer = useMemo(
+		() => getRegionsLabelsLayer(codeRegion ?? null),
+		[codeRegion],
+	);
+
 	const departementsLayer = useMemo(
 		() =>
 			getDepartementsLayer(
@@ -467,6 +472,10 @@ export default function FranceMap({ selectedPlaces, hideToolbar }: FranceMapProp
 	);
 	const departementLineLayer = useMemo(
 		() => getDepartementsLineLayer(codeDepartement ?? null),
+		[codeDepartement],
+	);
+	const departementsLabelsLayer = useMemo(
+		() => getDepartementsLabelsLayer(codeDepartement ?? null),
 		[codeDepartement],
 	);
 
@@ -635,9 +644,9 @@ export default function FranceMap({ selectedPlaces, hideToolbar }: FranceMapProp
 				)}
 				{!hideToolbar && (
 					<div className='absolute inset-x-0 bottom-24 z-legend flex flex-col items-start justify-center px-4 md:flex-row md:items-center md:justify-center md:gap-4'>
-					<Legend thresholds={COLOR_THRESHOLDS[level]} />
-					<MenuDrom />
-				</div>
+						<Legend thresholds={COLOR_THRESHOLDS[level]} />
+						<MenuDrom />
+					</div>
 				)}
 			</MapFromReactMapLibre>
 			{!hideToolbar && !isNationLevel && (

--- a/application/app/components/Map/MapWithFiches.tsx
+++ b/application/app/components/Map/MapWithFiches.tsx
@@ -4,6 +4,7 @@ import { Suspense } from 'react';
 
 import useActiveTab from '@/app/utils/hooks/useActiveTab';
 import useSelectedPlaces from '@/app/utils/hooks/useSelectedPlaces';
+import { useInitialView } from '@/app/utils/providers/initialViewProvider';
 
 import HomeOverlay from '../HomeOverlay/HomeOverlay';
 import Fiches from '../fiches/Fiches';
@@ -12,6 +13,7 @@ import FranceMap from './FranceMap';
 export default function MapWithFiches() {
 	const { etablissement, commune, departement, region, isFetching } = useSelectedPlaces();
 	const [isFicheOpen] = useActiveTab();
+	const { isInitialView } = useInitialView();
 
 	const selectedPlaces = { etablissement, commune, departement, region };
 
@@ -20,7 +22,7 @@ export default function MapWithFiches() {
 			<div className='relative flex-1'>
 				<Suspense>
 					<HomeOverlay />
-					<FranceMap selectedPlaces={selectedPlaces} />
+					<FranceMap selectedPlaces={selectedPlaces} hideToolbar={isInitialView} />
 				</Suspense>
 			</div>
 			{isFicheOpen && (

--- a/application/app/components/Map/layers/communesLayers.ts
+++ b/application/app/components/Map/layers/communesLayers.ts
@@ -62,19 +62,21 @@ export function getCommunesLineLayer(selectedCommuneId: string | null) {
  * Layer for the communes label.
  * When zooming out (after the minZoom), the labels are hidden because they are too small and decrease readability.
  */
-export const communesLabelsLayer = {
-	id: 'communes-labels',
-	type: 'symbol',
-	source: COMMUNES_LABELS_SOURCE_ID,
-	layout: {
-		'text-field': ['get', COMMUNE_GEOJSON_KEY_NOM],
-		'text-size': 14,
-		'text-anchor': 'center',
-	},
-	paint: {
-		'text-color': '#333333',
-		'text-halo-color': '#ffffff',
-		'text-halo-width': 1.5,
-	},
-	minzoom: 6.5,
-} satisfies LayerProps;
+export function getCommunesLabelLayer(isEtablissementLevel: boolean) {
+	return {
+		id: 'communes-labels',
+		type: 'symbol',
+		source: COMMUNES_LABELS_SOURCE_ID,
+		layout: {
+			'text-field': ['get', COMMUNE_GEOJSON_KEY_NOM],
+			'text-size': 16,
+			'text-anchor': 'center',
+		},
+		paint: {
+			'text-color': isEtablissementLevel ? '#ffffff' : '#333333',
+			'text-halo-width': isEtablissementLevel ? 0 : 1,
+			'text-halo-color': '#ffffff', // only useful if isEtablissementLevel is true
+		},
+		minzoom: 6.5,
+	} satisfies LayerProps;
+}

--- a/application/app/components/Map/layers/communesLayers.ts
+++ b/application/app/components/Map/layers/communesLayers.ts
@@ -60,7 +60,6 @@ export function getCommunesLineLayer(selectedCommuneId: string | null) {
 
 /**
  * Layer for the communes label.
- * When zooming out (after the minZoom), the labels are hidden because they are too small and decrease readability.
  */
 export function getCommunesLabelLayer(isEtablissementLevel: boolean) {
 	return {
@@ -77,6 +76,5 @@ export function getCommunesLabelLayer(isEtablissementLevel: boolean) {
 			'text-halo-width': isEtablissementLevel ? 0 : 1,
 			'text-halo-color': '#ffffff', // only useful if isEtablissementLevel is true
 		},
-		minzoom: 6.5,
 	} satisfies LayerProps;
 }

--- a/application/app/components/Map/layers/departementsLayers.ts
+++ b/application/app/components/Map/layers/departementsLayers.ts
@@ -52,22 +52,30 @@ export function getDepartementsLineLayer(selectedDepartementId: string | null) {
 
 /**
  * Labels for the departements layer.
- * When zooming out (after the minZoom), the labels are hidden because they are too small and decrease readability.
+ * We hide the label of the selected departement to avoid overlap with the commune label.
  */
-export const departementsLabelsLayer = {
-	id: 'departements-labels',
-	type: 'symbol',
-	source: DEPARTEMENTS_LABELS_SOURCE_ID,
-	layout: {
-		'text-field': ['get', DEPARTEMENT_GEOJSON_KEY_NOM],
-		'text-size': 15,
-		'text-anchor': 'center',
-		'text-max-width': 5,
-	},
-	paint: {
-		'text-color': '#333333',
-		'text-halo-color': '#ffffff',
-		'text-halo-width': 1,
-	},
-	minzoom: 5,
-} satisfies LayerProps;
+export function getDepartementsLabelsLayer(selectedDepartementId: string | null) {
+	return {
+		id: 'departements-labels',
+		type: 'symbol',
+		source: DEPARTEMENTS_LABELS_SOURCE_ID,
+		layout: {
+			'text-field': ['get', DEPARTEMENT_GEOJSON_KEY_NOM],
+			'text-size': 15,
+			'text-anchor': 'center',
+			'text-max-width': 5,
+		},
+		paint: {
+			'text-opacity': [
+				'match',
+				['get', DEPARTEMENT_GEOJSON_KEY_ID],
+				selectedDepartementId ?? '',
+				0,
+				1,
+			],
+			'text-color': '#333333',
+			'text-halo-color': '#ffffff',
+			'text-halo-width': 1,
+		},
+	} satisfies LayerProps;
+}

--- a/application/app/components/Map/layers/departementsLayers.ts
+++ b/application/app/components/Map/layers/departementsLayers.ts
@@ -67,7 +67,7 @@ export const departementsLabelsLayer = {
 	paint: {
 		'text-color': '#333333',
 		'text-halo-color': '#ffffff',
-		'text-halo-width': 2,
+		'text-halo-width': 1,
 	},
 	minzoom: 5,
 } satisfies LayerProps;

--- a/application/app/components/Map/layers/regionsLayers.ts
+++ b/application/app/components/Map/layers/regionsLayers.ts
@@ -50,19 +50,32 @@ export function getRegionsLineLayer(selectedRegionId: string | null) {
 	} satisfies LayerProps;
 }
 
-export const regionsLabelsLayer = {
-	id: 'regions-labels',
-	type: 'symbol',
-	source: REGIONS_LABELS_SOURCE_ID,
-	layout: {
-		'text-field': ['get', REGIONS_GEOJSON_KEY_NOM],
-		'text-size': 15,
-		'text-anchor': 'center',
-		'text-max-width': 5,
-	},
-	paint: {
-		'text-color': '#333333',
-		'text-halo-color': '#ffffff',
-		'text-halo-width': 1,
-	},
-} satisfies LayerProps;
+/**
+ * Labels for the regions layer.
+ * We hide the label of the selected region to avoid overlap with the departement label.
+ */
+export function getRegionsLabelsLayer(selectedRegionId: string | null) {
+	return {
+		id: 'regions-labels',
+		type: 'symbol',
+		source: REGIONS_LABELS_SOURCE_ID,
+		layout: {
+			'text-field': ['get', REGIONS_GEOJSON_KEY_NOM],
+			'text-size': 15,
+			'text-anchor': 'center',
+			'text-max-width': 5,
+		},
+		paint: {
+			'text-opacity': [
+				'match',
+				['get', REGIONS_GEOJSON_KEY_ID],
+				selectedRegionId ?? '',
+				0,
+				1,
+			],
+			'text-color': '#333333',
+			'text-halo-color': '#ffffff',
+			'text-halo-width': 1,
+		},
+	} satisfies LayerProps;
+}

--- a/application/app/components/Map/layers/regionsLayers.ts
+++ b/application/app/components/Map/layers/regionsLayers.ts
@@ -63,6 +63,6 @@ export const regionsLabelsLayer = {
 	paint: {
 		'text-color': '#333333',
 		'text-halo-color': '#ffffff',
-		'text-halo-width': 2,
+		'text-halo-width': 1,
 	},
 } satisfies LayerProps;


### PR DESCRIPTION
### Description
Github issue : #318 

Cette PR a pour objectif d'améliorer la lisibilité des labels sur la carte.
- régions, départements, commmunes (hors vue etablissement) -> texte `#333333` + halo blanc 1px 
- commune (vue etablissement) -> texte blanc sans halo

J'ai aussi caché par défaut les boutons de la carte (+/-, menu drom)  sur la vue initiale comme demandé dans #314 

### Comment tester ?
Vue commune : 
<img width="443" height="820" alt="image" src="https://github.com/user-attachments/assets/86202fea-6d28-4ba4-8973-e35056879a50" />

vue departement : 
<img width="443" height="820" alt="image" src="https://github.com/user-attachments/assets/8a081def-51d3-473b-8718-e4a39ac3a302" />

vue departement avec dezoom:
<img width="443" height="820" alt="image" src="https://github.com/user-attachments/assets/4188b264-a59e-46a0-bca1-ce67432a5555" />

vue initiale : 
<img width="443" height="820" alt="image" src="https://github.com/user-attachments/assets/66eafddb-3a38-48d7-abcd-579633647a2b" />


### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [ ] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
