### PR TITLE
fix: middleware now allow switching tabs if in match any of the code …

### DIFF
--- a/application/app/components/fiches/Fiches.tsx
+++ b/application/app/components/fiches/Fiches.tsx
@@ -8,7 +8,7 @@ import { Etablissement } from '@/app/models/etablissements';
 import { Region } from '@/app/models/regions';
 import useActiveTab from '@/app/utils/hooks/useActiveTab';
 import useURLParams, { Codes } from '@/app/utils/hooks/useURLParams';
-import { codesDiffer } from '@/app/utils/state-utils';
+import { ALLOWED_TABS, codesDiffer } from '@/app/utils/state-utils';
 import { X } from 'lucide-react';
 
 import Loading from '../Loading';
@@ -36,7 +36,8 @@ const actionsShort = [
 	},
 ];
 
-export type TabId = 'region' | 'departement' | 'commune' | 'etablissement';
+export type TabId = (typeof ALLOWED_TABS)[number];
+
 type Tab = { id: TabId; label?: string }[];
 
 interface FichesProps {

--- a/application/app/utils/state-utils.ts
+++ b/application/app/utils/state-utils.ts
@@ -17,6 +17,7 @@ export function codesDiffer(codes1: Codes, codes2: Codes): boolean {
 }
 
 export const ACTIVE_TAB_KEY = 'activeTab';
+export const ALLOWED_TABS = ['region', 'departement', 'commune', 'etablissement'] as const;
 
 export function buildActiveTabParam(tabId: TabId): URLSearchParams {
 	return new URLSearchParams({ [ACTIVE_TAB_KEY]: tabId });
@@ -40,6 +41,16 @@ export const LEVEL_CODE_HIERARCHY: Array<keyof Codes> = [
 	CODE_COMMUNES_KEY,
 	CODE_ETABLISSEMENTS_KEY,
 ] as const;
+
+/**
+ * Map a TabId to a code key.
+ */
+export const TAB_ID_TO_CODE_MAP: Record<TabId, keyof Codes> = {
+	region: 'codeRegion',
+	departement: 'codeDepartement',
+	commune: 'codeCommune',
+	etablissement: 'codeEtablissement',
+};
 
 /**
  * Map a code key to a TabId.
@@ -72,4 +83,19 @@ export function getLongestValidHierarchy(codes: Codes): [Codes, keyof Codes | nu
 		validLevels[level] = codes[level];
 	}
 	return [validLevels, lastValidLevel];
+}
+
+/**
+ * Checks that the activeTabParam is valid:
+ * - is one of the allowed tabs
+ * - corresponds to a non-null code in the provided Codes (meaning the level will load)
+ * @param activeTabParam
+ * @param codes
+ * @returns
+ */
+export function isTabValid(activeTabParam: string, codes: Codes): boolean {
+	return (
+		ALLOWED_TABS.includes(activeTabParam as TabId) &&
+		codes[TAB_ID_TO_CODE_MAP[activeTabParam as TabId]] !== null
+	);
 }


### PR DESCRIPTION
### Description
Github issue : N/A

Cette PR a pour objectif de corriger l'accès aux tabs depuis les fiches.
Le middleware précedemment ajouté considérait qu'un tab était invalide si elle ne correspondait pas au dernier niveau.
C'est corrigé ici pour pouvoir naviguer sur une tab d'un niveau inférieur.

Related to #308 

### Comment tester ?
Navigation sur les tabs des fiches + accès lien direct top 3 et groupe scolaire + suppression d'un element de l'url.

### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [ ] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !