### PR TITLE
fix: test env safe-area values for padding

### DIFF
--- a/application/app/components/Map/MapWithFiches.tsx
+++ b/application/app/components/Map/MapWithFiches.tsx
@@ -18,7 +18,7 @@ export default function MapWithFiches() {
 	const selectedPlaces = { etablissement, commune, departement, region };
 
 	return (
-		<div className='relative flex-1'>
+		<div className='pb-safe-bottom relative flex-1'>
 			<Suspense>
 				<HomeOverlay />
 				<FranceMap selectedPlaces={selectedPlaces} hideToolbar={isInitialView} />

--- a/application/tailwind.config.ts
+++ b/application/tailwind.config.ts
@@ -107,6 +107,12 @@ export default {
 				'slide-in-bottom': 'slide-in-bottom 0.4s ease-out',
 				'slide-in': 'slide-in 1.5s ease-out forwards',
 			},
+			padding: {
+				'safe-bottom': 'env(safe-area-inset-bottom)',
+				'safe-top': 'env(safe-area-inset-top)',
+				'safe-left': 'env(safe-area-inset-left)',
+				'safe-right': 'env(safe-area-inset-right)',
+			},
 		},
 	},
 	// eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
### Description
Github issue : N/A

Cette PR a pour objectif de corriger la vue mobile de la carte où un navigateur avec la barre d'url positionné en bas cache les menus des DROM.

### Comment tester ?
Déploiement + test sur mobile

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !