### PR TITLE
fix: (map) update point protege text

### DIFF
--- a/application/app/components/Map/layers/etablissementsLayers.ts
+++ b/application/app/components/Map/layers/etablissementsLayers.ts
@@ -122,7 +122,7 @@ export const unclusteredPointProtegeIconLayer = {
 		['==', ['get', ETABLISSEMENT_GEOJSON_KEY_PROTECTION], true],
 	],
 	layout: {
-		'text-field': 'i',
+		'text-field': '!',
 		'text-size': 20,
 	},
 	paint: {

--- a/application/app/components/fiches/NbEtablissements.tsx
+++ b/application/app/components/fiches/NbEtablissements.tsx
@@ -34,7 +34,7 @@ const NbEtablissements: React.FC<NbEtablissementsProps> = ({ niveau, nbEtablisse
 		<>
 			<div className='flex gap-1 text-grey'>
 				<University />
-				<p className='text-sm font-bold'>Nombre total {getNiveauLabel(niveau)} :</p>
+				<p className='text-sm font-bold'>Nombre total {getNiveauLabel(niveau)}&nbsp;:</p>
 			</div>
 			<p className='font-bold text-grey'>
 				&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;

--- a/application/app/components/fiches/shared/PotentielSolaireCard.tsx
+++ b/application/app/components/fiches/shared/PotentielSolaireCard.tsx
@@ -45,7 +45,7 @@ export default function PotentielSolaireCard({
 		return (
 			<div className='mb-4 rounded-2xl border-8 border-solid bg-slate-100 p-6 outline-select'>
 				<div className='flex items-center text-grey'>
-					<FileX className='h-8 w-8 mt-2 flex-shrink-0 self-stretch' />
+					<FileX className='mt-2 h-8 w-8 flex-shrink-0 self-stretch' />
 					<p className='ml-2 text-base font-semibold'>
 						Données incomplètes pour cet établissement
 					</p>
@@ -67,13 +67,13 @@ export default function PotentielSolaireCard({
 						</p>
 					</>
 				) : (
-					<span className='text-gray-500 italic'>{UNKNOWN_TEXTS.nbEleves}</span>
+					<span className='italic text-gray-500'>{UNKNOWN_TEXTS.nbEleves}</span>
 				)}
 			</div>
 
 			<div className='mt-5 flex gap-1 text-grey'>
 				<Zap />
-				<p className='text-sm font-bold'>Potentiel de production annuelle </p>
+				<p className='text-sm font-bold'>Potentiel de production annuelle&nbsp;:</p>
 			</div>
 			<div className='flex items-center gap-2 font-bold text-blue'>
 				{potentielSolaire !== undefined && level ? (
@@ -92,7 +92,7 @@ export default function PotentielSolaireCard({
 			<div className='flex gap-1 text-grey'>
 				<HousePlug size={36} />
 				<p className='text-sm font-bold'>
-					&nbsp;Équivalent à la consommation électrique annuelle de :
+					&nbsp;Équivalent à la consommation électrique annuelle de&nbsp;:
 				</p>
 			</div>
 			<div className='flex w-full items-center justify-between ps-7 text-darkgreen'>
@@ -107,7 +107,7 @@ export default function PotentielSolaireCard({
 					<Popover.Trigger asChild>
 						<button
 							aria-disabled='true'
-							className='hover:bg-gray-100 rounded p-2 text-darkgreen transition'
+							className='rounded p-2 text-darkgreen transition hover:bg-gray-100'
 						>
 							<CircleHelp />
 						</button>

--- a/application/app/components/fiches/shared/RepartitionPotentielSolaire.tsx
+++ b/application/app/components/fiches/shared/RepartitionPotentielSolaire.tsx
@@ -21,8 +21,8 @@ export default function RepartitionPotentielSolaire({
 		<div className='mb-4'>
 			<div>
 				<div className='flex items-center gap-2 text-sm font-bold text-grey'>
-					<div className='border-1 h-4 w-4 rounded-full border border-slate-400 bg-sol_top' />
-					<span>{niveau} au potentiel solaire élevé</span>
+					<div className='border-1 h-4 w-4 shrink-0 rounded-full border border-slate-400 bg-sol_top' />
+					<span>{niveau} au potentiel solaire élevé&nbsp;:</span>
 				</div>
 				<p className='text-center text-base font-bold text-blue'>
 					{renderValeur(repartition['1_HIGH'])}
@@ -31,8 +31,8 @@ export default function RepartitionPotentielSolaire({
 			<br />
 			<div>
 				<div className='flex items-center gap-2 text-sm font-bold text-grey'>
-					<div className='border-1 h-4 w-4 rounded-full border border-slate-400 bg-sol_ok' />
-					<span>{niveau} au potentiel solaire bon</span>
+					<div className='border-1 h-4 w-4 shrink-0 rounded-full border border-slate-400 bg-sol_ok' />
+					<span>{niveau} au potentiel solaire bon&nbsp;:</span>
 				</div>
 				<p className='text-center text-base font-bold text-blue'>
 					{renderValeur(repartition['2_GOOD'])}
@@ -42,8 +42,8 @@ export default function RepartitionPotentielSolaire({
 			<br />
 			<div>
 				<div className='flex items-center gap-2 text-sm font-bold text-grey'>
-					<div className='border-1 h-4 w-4 rounded-full border border-slate-400 bg-sol_ko' />
-					<span>{niveau} au potentiel solaire limité</span>
+					<div className='border-1 h-4 w-4 shrink-0 rounded-full border border-slate-400 bg-sol_ko' />
+					<span>{niveau} au potentiel solaire limité&nbsp;:</span>
 				</div>
 				<p className='text-center text-base font-bold text-blue'>
 					{renderValeur(repartition['3_LIMITED'])}


### PR DESCRIPTION
### Description
Github issue : #335 

Cette PR a pour objectif de corriger deux élements d'interface : 
- le point protégé d'un établissement doit afficher un `!` comme sur la fiche et plus un `i`
- les libellés des chiffres détaillés doivent terminer par `:` insécable pour eviter de revenir à la ligne

### Comment tester ?
<img width="669" height="798" alt="image" src="https://github.com/user-attachments/assets/44b78540-4211-4926-bc2f-514fc4fed5f3" />

<img width="490" height="614" alt="image" src="https://github.com/user-attachments/assets/6396dd96-b9d2-4871-aaa4-bacb727ac30e" />


### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
