### PR TITLE
fix: use dvh unit for the 100vh mobile bug

### DIFF
--- a/application/app/layout.tsx
+++ b/application/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang='en' className='h-full'>
-			<body className='flex min-h-screen flex-col bg-blue'>
+			<body className='flex min-h-dvh flex-col bg-blue'>
 				<Suspense>
 					<InitialViewProvider>
 						<NavBar />


### PR DESCRIPTION
### Description
Github issue : N/A

Cette PR a pour objectif de corriger la vue mobile de la carte où un navigateur avec la barre d'url positionné en bas cache les menus des DROM.
Test avec une unité de viewport dynamique `dvh`

### Comment tester ?
Déploiement + test sur mobile

### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)