### PR TITLE
feature: add seuils by type etablissement

### DIFF
--- a/application/app/components/Map/constants.ts
+++ b/application/app/components/Map/constants.ts
@@ -1,3 +1,4 @@
+import { TypeEtablissement } from '@/app/models/etablissements';
 import { ColorSpecification } from 'maplibre-gl';
 
 import { Level } from './interfaces';
@@ -10,6 +11,8 @@ export const SCALE_COLORS = {
 	middle: '#faea5e',
 	high: '#e19803',
 } as const;
+
+// ---- Seuils globaux : Tous type d'etablissements ----
 
 /** In kWh */
 const ETABLISSEMENTS_COLOR_THRESHOLDS: Thresholds = {
@@ -57,4 +60,42 @@ export const COLOR_THRESHOLDS: Record<Level, Thresholds> = {
 	departement: COMMUNES_COLOR_THRESHOLDS,
 	region: DEPARTEMENTS_COLOR_THRESHOLDS,
 	nation: REGIONS_COLOR_THRESHOLDS,
+};
+
+// ---- Seuils par type d'etablissement ----
+
+/** In kWh */
+/**
+ * Lycées dépend des régions
+ */
+const LYCEES_COLOR_THRESHOLDS: Thresholds = {
+	0: SCALE_COLORS.low,
+	139363325: SCALE_COLORS.middle,
+	293551410: SCALE_COLORS.high,
+};
+
+/** In kWh */
+/**
+ * Collèges dépend des départements
+ */
+const COLLEGES_COLOR_THRESHOLDS: Thresholds = {
+	0: SCALE_COLORS.low,
+	18709211: SCALE_COLORS.middle,
+	36465161: SCALE_COLORS.high,
+};
+
+/** In kWh */
+/**
+ * Écoles dépend des communes
+ */
+const ECOLES_COLOR_THRESHOLDS: Thresholds = {
+	0: SCALE_COLORS.low,
+	74449: SCALE_COLORS.middle,
+	198542: SCALE_COLORS.high,
+};
+
+export const COLOR_THRESHOLDS_BY_TYPE_ETABLISSEMENT: Record<TypeEtablissement, Thresholds> = {
+	Lycée: LYCEES_COLOR_THRESHOLDS,
+	Collège: COLLEGES_COLOR_THRESHOLDS,
+	Ecole: ECOLES_COLOR_THRESHOLDS,
 };

--- a/application/app/components/fiches/ficheCommune.tsx
+++ b/application/app/components/fiches/ficheCommune.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Commune } from '@/app/models/communes';
 
+import { COLOR_THRESHOLDS, COLOR_THRESHOLDS_BY_TYPE_ETABLISSEMENT } from '../Map/constants';
 import NbEtablissements from './NbEtablissements';
 import ActionButtons from './shared/ActionButtons';
 import CollectiviteHeaderCard from './shared/CollectiviteHeaderCard';
@@ -56,7 +57,7 @@ export default function FicheCommune({
 						potentielSolaire={commune.potentiel_solaire_total}
 						potentielNbFoyers={commune.potentiel_nb_foyers_total}
 						nbEleves={commune.nb_eleves_total}
-						level='commune'
+						thresholds={COLOR_THRESHOLDS['commune']}
 						header={
 							<NbEtablissements
 								nbEtablissements={commune.nb_etablissements_total}
@@ -78,6 +79,7 @@ export default function FicheCommune({
 						potentielSolaire={commune.potentiel_solaire_primaires}
 						potentielNbFoyers={commune.potentiel_nb_foyers_primaires}
 						nbEleves={commune.nb_eleves_primaires}
+						thresholds={COLOR_THRESHOLDS_BY_TYPE_ETABLISSEMENT['Ecole']}
 						header={
 							<NbEtablissements
 								nbEtablissements={commune.nb_etablissements_primaires}

--- a/application/app/components/fiches/ficheDepartement.tsx
+++ b/application/app/components/fiches/ficheDepartement.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Departement } from '@/app/models/departements';
 
+import { COLOR_THRESHOLDS, COLOR_THRESHOLDS_BY_TYPE_ETABLISSEMENT } from '../Map/constants';
 import NbEtablissements from './NbEtablissements';
 import ActionButtons from './shared/ActionButtons';
 import CollectiviteHeaderCard from './shared/CollectiviteHeaderCard';
@@ -56,7 +57,7 @@ export default function FicheDepartement({
 						potentielSolaire={departement.potentiel_solaire_total}
 						potentielNbFoyers={departement.potentiel_nb_foyers_total}
 						nbEleves={departement.nb_eleves_total}
-						level='departement'
+						thresholds={COLOR_THRESHOLDS['departement']}
 						header={
 							<NbEtablissements
 								nbEtablissements={departement.nb_etablissements_total}
@@ -78,6 +79,7 @@ export default function FicheDepartement({
 						potentielSolaire={departement.potentiel_solaire_colleges}
 						potentielNbFoyers={departement.potentiel_nb_foyers_colleges}
 						nbEleves={departement.nb_eleves_colleges}
+						thresholds={COLOR_THRESHOLDS_BY_TYPE_ETABLISSEMENT['Collège']}
 						header={
 							<NbEtablissements
 								nbEtablissements={departement.nb_etablissements_colleges}

--- a/application/app/components/fiches/ficheRegion.tsx
+++ b/application/app/components/fiches/ficheRegion.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Region } from '@/app/models/regions';
 
+import { COLOR_THRESHOLDS, COLOR_THRESHOLDS_BY_TYPE_ETABLISSEMENT } from '../Map/constants';
 import NbEtablissements from './NbEtablissements';
 import ActionButtons from './shared/ActionButtons';
 import CollectiviteHeaderCard from './shared/CollectiviteHeaderCard';
@@ -57,7 +58,7 @@ export default function FicheRegion({
 						potentielSolaire={region.potentiel_solaire_total}
 						potentielNbFoyers={region.potentiel_nb_foyers_total}
 						nbEleves={region.nb_eleves_total}
-						level='region'
+						thresholds={COLOR_THRESHOLDS['region']}
 						header={
 							<NbEtablissements
 								nbEtablissements={region.nb_etablissements_total}
@@ -79,6 +80,7 @@ export default function FicheRegion({
 						potentielSolaire={region.potentiel_solaire_lycees}
 						potentielNbFoyers={region.potentiel_nb_foyers_lycees}
 						nbEleves={region.nb_eleves_lycees}
+						thresholds={COLOR_THRESHOLDS_BY_TYPE_ETABLISSEMENT['Lycée']}
 						header={
 							<NbEtablissements
 								nbEtablissements={region.nb_etablissements_lycees}

--- a/application/app/components/fiches/shared/PotentielSolaireCard.tsx
+++ b/application/app/components/fiches/shared/PotentielSolaireCard.tsx
@@ -5,19 +5,18 @@ import * as Popover from '@radix-ui/react-popover';
 import { CircleHelp, FileX, HousePlug, Users, Zap } from 'lucide-react';
 
 import { getClosestEnergyUnit, getFormattedPotentielSolaire } from '../../../utils/energy-utils';
+import { Thresholds } from '../../Map/constants';
 
 const UNKNOWN_TEXTS = {
 	potentielSolaire: '—',
 	nbEleves: "Nombre d'élèves concernés inconnu",
 };
 
-type CarteLevel = 'etablissement' | 'commune' | 'departement' | 'region';
-
 interface PotentielSolaireCardProps {
 	potentielSolaire?: number;
 	potentielNbFoyers?: number;
 	nbEleves?: number;
-	level?: CarteLevel;
+	thresholds: Thresholds;
 	header?: React.ReactNode;
 	grise?: boolean;
 }
@@ -39,7 +38,7 @@ export default function PotentielSolaireCard({
 	potentielSolaire,
 	potentielNbFoyers,
 	nbEleves,
-	level,
+	thresholds,
 	header,
 	grise,
 }: PotentielSolaireCardProps) {
@@ -78,10 +77,12 @@ export default function PotentielSolaireCard({
 				<p className='text-sm font-bold'>Potentiel de production annuelle&nbsp;:</p>
 			</div>
 			<div className='flex items-center gap-2 font-bold text-blue'>
-				{potentielSolaire !== undefined && level ? (
+				{potentielSolaire !== undefined ? (
 					<div
 						className='border-1 print-bg h-4 w-4 rounded-full border border-slate-400'
-						style={{ backgroundColor: getColorForPotentiel(level, potentielSolaire) }}
+						style={{
+							backgroundColor: getColorForPotentiel(thresholds, potentielSolaire),
+						}}
 					/>
 				) : (
 					<div className='border-1 h-4 w-4 rounded-full border border-slate-400' />

--- a/application/app/utils/solar-utils.ts
+++ b/application/app/utils/solar-utils.ts
@@ -1,9 +1,6 @@
-import { COLOR_THRESHOLDS } from '../components/Map/constants';
+import { Thresholds } from '../components/Map/constants';
 
-export type CarteLevel = 'etablissement' | 'commune' | 'departement' | 'region';
-
-export function getColorForPotentiel(level: CarteLevel, potentiel: number): string {
-	const thresholds = COLOR_THRESHOLDS[level];
+export function getColorForPotentiel(thresholds: Thresholds, potentiel: number): string {
 	const entries = Object.entries(thresholds)
 		.map(([threshold, color]) => [Number(threshold), color] as [number, string])
 		.sort((a, b) => a[0] - b[0]);


### PR DESCRIPTION
### Description
Github issue : #218 

Cette PR a pour objectif de rajouter les seuils par type etablissement.
Le cercle avant le potentiel doit maintenant afficher une couleur pour les etablissements sous responsabilités des différents niveaux.

### Comment tester ?
<img width="437" height="815" alt="image" src="https://github.com/user-attachments/assets/79893425-7201-4005-9804-8256629d58df" />

### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [ ] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)
