### PR TITLE
[FRONT] Reset isOpen on footer after redirection

### DIFF
--- a/application/app/components/Footer.tsx
+++ b/application/app/components/Footer.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { usePathname } from 'next/navigation';
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { ArrowUpCircle } from 'lucide-react';
 


### PR DESCRIPTION
### Description

Cette PR a pour objectif de forcer la fermeture du footer quand on utilise un lien de redirection.

### Comment tester ?
Avant 
https://github.com/user-attachments/assets/741266ce-961a-4c32-a272-8c6ef9071b6a

Après
https://github.com/user-attachments/assets/046e4ba3-6a08-493a-9ce2-a2300fd06512


### Pour faciliter la validation de ma PR
- [ ] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code
Non obligatoires mais fortement appréciées !

#### Si ca concerne le code de l'application web
- Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- Le linter ne remonte pas d'erreur : `npm run lint`
- J'évite d'utiliser le type `any`
