### PR TITLE
[FRONT] Move Fiches panel from right to left side

### DIFF
--- a/application/app/components/fiches/Fiches.tsx
+++ b/application/app/components/fiches/Fiches.tsx
@@ -190,7 +190,7 @@ export default function Fiches({
 
 	return (
 		<div
-			className={`fixed right-0 top-0 z-fiche h-full w-full animate-slide-in-bottom overflow-y-auto bg-white pl-5 pr-3 pt-1 shadow-lg md:w-2/5 md:max-w-[450px] md:animate-slide-in-right md:rounded-md xl:absolute`}
+			className={`fixed left-0 top-0 z-fiche h-full w-full animate-slide-in-bottom overflow-y-auto bg-white pl-3 pr-5 pt-1 shadow-lg md:w-2/5 md:max-w-[450px] md:animate-slide-in-left md:rounded-md xl:absolute`}
 			role='region'
 			aria-label={`Fiche ${activeTab}`}
 		>

--- a/application/tailwind.config.ts
+++ b/application/tailwind.config.ts
@@ -93,6 +93,10 @@ export default {
 					'0%': { transform: 'translateX(100%)', opacity: '0' },
 					'100%': { transform: 'translateX(0)', opacity: '1' },
 				},
+				'slide-in-left': {
+					'0%': { transform: 'translateX(-100%)', opacity: '0' },
+					'100%': { transform: 'translateX(0)', opacity: '1' },
+				},
 				'slide-in-bottom': {
 					'0%': { transform: 'translateY(100%)', opacity: '0' },
 					'100%': { transform: 'translateY(0)', opacity: '1' },
@@ -104,6 +108,7 @@ export default {
 			},
 			animation: {
 				'slide-in-right': 'slide-in-right 0.4s ease-out',
+				'slide-in-left': 'slide-in-left 0.4s ease-out',
 				'slide-in-bottom': 'slide-in-bottom 0.4s ease-out',
 				'slide-in': 'slide-in 1.5s ease-out forwards',
 			},


### PR DESCRIPTION
### Description
Cette PR a pour objectif de repositionner le panneau Fiches du côté gauche de l'écran au lieu du côté droit.

### Comment tester ?
1. Démarrer l'application en local : `npm run dev`
2. Ouvrir l'application dans le navigateur
3. Cliquer sur une école/commune/département/région pour ouvrir le panneau Fiches
4. Vérifier que le panneau apparaît sur le côté gauche avec une animation de glissement depuis la gauche (sur desktop)
5. Sur mobile, le panneau devrait toujours glisser depuis le bas

### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Le code modifié fonctionne en local
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)

### Bonnes pratiques de code

#### Si ca concerne le code de l'application web
- [x] Je m'assure que mon code est à jour par rapport à la branche `main` pour tester avec la dernière version du code
- [ ] Le linter ne remonte pas d'erreur : `npm run lint`
- [x] J'évite d'utiliser le type `any`

### Changements techniques
- Ajout de l'animation `slide-in-left` dans la configuration Tailwind
- Modification du composant Fiches pour utiliser `left-0` au lieu de `right-0`
- Ajustement du padding pour un meilleur alignement à gauche

🤖 Generated with [Claude Code](https://claude.com/claude-code)