### PR TITLE
Update footer link to open data set

### DIFF
--- a/application/app/content/footer.ts
+++ b/application/app/content/footer.ts
@@ -13,7 +13,7 @@ export const footerLinks = [
 	},
 	{
 		title: 'Jeu de données ouvert',
-		href: 'https://drive.google.com/drive/folders/1c2h-0lhFIzdnwxm5ojmMq1p67XBY41IA?usp=sharing',
+		href: 'https://www.data.gouv.fr/datasets/quel-est-le-potentiel-solaire-des-toitures-des-etablissements-scolaires-publics-francais/',
 	},
 	// { title: 'Accessibilité du site', href: '/accessibilite-du-site', priority: 0.3 },
 ];


### PR DESCRIPTION
### Description
Github issue : #368 

Cette PR a pour objectif de rajouter le lien des données publiées sur datagouv après publication par GP. 

### Comment tester ?
Le lien du footer doit pointer sur le nouveau lien datagouv.

### Pour faciliter la validation de ma PR
- [x] J'ai pris connaissance et respecté les [règles de contribution](../CONTRIBUTING.md)
- [x] Les pre-commit passent
- [ ] Les test unitaires passent
- [x] Le code modifié fonctionne en local
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] J'ai ajouté / mis à jour de la documentation sur [outline](https://outline.services.dataforgood.fr/collection/13_potentiel_scolaire-qJFjGnz5Ec)